### PR TITLE
fix: accept null standup channel from API

### DIFF
--- a/src/handlers/standup-handlers.ts
+++ b/src/handlers/standup-handlers.ts
@@ -133,7 +133,7 @@ async function enrichNotFound(
 export interface StandupBrief {
 	id: number;
 	name: string;
-	channel: string;
+	channel: string | null;
 	time: string;
 	timezone: string;
 	days: string[];
@@ -162,7 +162,7 @@ export async function handleStandupList(
 
 	if (options.channel) {
 		const needle = options.channel.toLowerCase();
-		standups = standups.filter((s) => s.channel.toLowerCase().includes(needle));
+		standups = standups.filter((s) => s.channel?.toLowerCase().includes(needle) ?? false);
 	}
 
 	if (options.mine) {
@@ -530,7 +530,7 @@ function buildReplaceUndoCommand(id: number, prev: Standup): string {
 	const parts: string[] = [`geekbot standup replace ${id}`];
 
 	parts.push(`--name ${shellEscape(prev.name)}`);
-	parts.push(`--channel ${shellEscape(prev.channel)}`);
+	parts.push(`--channel ${shellEscape(prev.channel ?? "")}`);
 
 	if (prev.time) {
 		parts.push(`--time ${shellEscape(prev.time.slice(0, 5))}`);

--- a/src/schemas/standup.ts
+++ b/src/schemas/standup.ts
@@ -25,7 +25,7 @@ export type Question = z.output<typeof QuestionSchema>;
 const StandupRawSchema = z.object({
 	id: z.number(),
 	name: z.string(),
-	channel: z.string(),
+	channel: z.string().nullable(),
 	channel_id: z.string().optional(),
 	time: z.string(),
 	timezone: TimezoneSchema,

--- a/src/utils/receipt.ts
+++ b/src/utils/receipt.ts
@@ -26,7 +26,7 @@ export function buildReceipt(
  */
 export function buildDeleteUndoCommand(standup: Standup): string {
 	const parts: string[] = [
-		`geekbot standup create --name ${shellEscape(standup.name)} --channel ${shellEscape(standup.channel)}`,
+		`geekbot standup create --name ${shellEscape(standup.name)} --channel ${shellEscape(standup.channel ?? "")}`,
 	];
 
 	if (standup.time) {

--- a/tests/schemas/standup.test.ts
+++ b/tests/schemas/standup.test.ts
@@ -65,6 +65,11 @@ describe("StandupSchema", () => {
 		expect(standup.draft).toBeUndefined();
 		expect(standup.paused).toBeUndefined();
 	});
+
+	test("accepts null channel (e.g. DM-mode or unassigned standups)", () => {
+		const standup = StandupSchema.parse({ ...BASE_STANDUP, wait_time: 60, channel: null });
+		expect(standup.channel).toBeNull();
+	});
 });
 
 describe("StandupSchema negative tests", () => {


### PR DESCRIPTION
## Summary
- `StandupRawSchema.channel` was `z.string()`, so any API response with `channel: null` (DM-mode or unassigned standups) would fail Zod parsing and surface as a generic schema error to the user.
- Made `channel` nullable and updated the three consumers that read it — the `standup list --channel` filter, and the replace/delete undo command builders — to handle null safely.

## Changes
- `src/schemas/standup.ts` — `channel: z.string().nullable()`
- `src/handlers/standup-handlers.ts` — `StandupBrief.channel: string | null`; list filter uses `?.toLowerCase() ?? false`; replace undo falls back to `""`
- `src/utils/receipt.ts` — delete undo falls back to `""`
- `tests/schemas/standup.test.ts` — added null channel parsing test

## Test plan
- [x] `bun test` — 588 pass / 0 fail
- [x] New test verifies null channel parses and normalizes to `null`
- [x] Existing undo/filter tests still pass (fixtures use string channel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)