### PR TITLE
ci: isolate commander-error test to prevent mock.module formatter leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
           bun test tests/auth/ tests/http/ tests/output/ tests/utils/ tests/schemas/
           bun test tests/errors/error-handler.test.ts tests/errors/cli-error.test.ts tests/errors/not-found-helper.test.ts tests/errors/exit-codes.test.ts
           bun test tests/errors/error-handler-output.test.ts
-          bun test tests/handlers/ tests/cli/ tests/ci/
+          bun test tests/cli/commander-error.test.ts
+          bun test tests/handlers/ tests/cli/commands/ tests/cli/globals.test.ts tests/cli/index.test.ts tests/ci/
 
   test-macos:
     needs: [lint, typecheck]
@@ -53,7 +54,8 @@ jobs:
           bun test tests/auth/ tests/http/ tests/output/ tests/utils/ tests/schemas/
           bun test tests/errors/error-handler.test.ts tests/errors/cli-error.test.ts tests/errors/not-found-helper.test.ts tests/errors/exit-codes.test.ts
           bun test tests/errors/error-handler-output.test.ts
-          bun test tests/handlers/ tests/cli/ tests/ci/
+          bun test tests/cli/commander-error.test.ts
+          bun test tests/handlers/ tests/cli/commands/ tests/cli/globals.test.ts tests/cli/index.test.ts tests/ci/
 
   coverage:
     needs: [lint, typecheck]
@@ -67,7 +69,8 @@ jobs:
         run: |
           bun test --coverage tests/auth/ tests/http/ tests/output/ tests/utils/ tests/schemas/ tests/errors/error-handler.test.ts tests/errors/cli-error.test.ts tests/errors/not-found-helper.test.ts tests/errors/exit-codes.test.ts 2>&1 | tee coverage-output.txt
           bun test tests/errors/error-handler-output.test.ts
-          bun test tests/handlers/ tests/cli/ tests/ci/
+          bun test tests/cli/commander-error.test.ts
+          bun test tests/handlers/ tests/cli/commands/ tests/cli/globals.test.ts tests/cli/index.test.ts tests/ci/
       - name: Enforce 95% line coverage threshold
         run: |
           COVERAGE=$(grep 'All files' coverage-output.txt | awk -F'|' '{for(i=1;i<=NF;i++){gsub(/^ +| +$/,"",$i)}}; {print $3}')


### PR DESCRIPTION
## Summary

Fixes #2. 5 tests in `tests/cli/commander-error.test.ts` were failing on `test-linux` and `coverage` jobs with `SyntaxError: JSON Parse error: Unexpected EOF` at `JSON.parse(stdoutOutput.trim())`.

## Root cause

The 7 handler test files in `tests/handlers/` each call `mock.module("../../src/output/formatter.ts", ...)` at module-evaluation time, replacing `writeOutput` with a no-op `mock(() => {})`. Bun's test runner loads/evaluates every target file before executing any tests when given a single `bun test tests/handlers/ tests/cli/ tests/ci/` invocation, so by the time `commander-error.test.ts` ran, `writeOutput` was already a no-op — nothing was ever written to stdout, hence the empty buffer and the EOF crash.

This is the same `bun#12823` mock-leak pattern already worked around for `tests/errors/error-handler-output.test.ts` in commit `c249419`. The leak became visible on Linux only after the mutable `oven/bun:1.3.11` container image was republished sometime between 2026-03-27 (last green main run) and 2026-04-23 with a Bun build that changed module discovery ordering.

## Fix

Splits `commander-error.test.ts` into its own bun invocation in all three test jobs (`test-linux`, `test-macos`, `coverage`), matching the existing isolation pattern. The remaining `tests/cli/` files (`commands/`, `globals.test.ts`, `index.test.ts`) still run alongside `tests/handlers/` since they don't depend on the real `writeOutput`.

No source or test code changes — only the CI workflow.

## Test plan

- [x] `bun test tests/cli/commander-error.test.ts` — 8 pass (locally)
- [x] `bun test tests/handlers/ tests/cli/commands/ tests/cli/globals.test.ts tests/cli/index.test.ts tests/ci/` — 238 pass (locally)
- [ ] CI on Linux + coverage jobs pass

## What I tried first

Initial attempt was a test-side fix (replace `spyOn(process.stdout, "write")` with direct assignment, per a subagent's research). Pushed and CI still failed with the same error — that confirmed the issue isn't with how the spy installs, it's that `writeOutput` itself was already module-mocked away before the test had a chance to install any stdout interception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
