### PR TITLE
fix: accept object day/month in poll recurrence schema (#5)

### DIFF
--- a/src/schemas/poll.ts
+++ b/src/schemas/poll.ts
@@ -11,14 +11,36 @@ const PollQuestionSchema = z.object({
 	one_option_limit: z.boolean(),
 });
 
+/**
+ * Recurrence day/month fields. The upstream poll-job-scheduler emits these as objects
+ * with `value` and/or `order` keys (e.g. `{ value: "monday" }`, `{ order: "2nd", value: "wednesday" }`,
+ * `{ order: "1st" }`, `{ value: "july" }`). A legacy string form (`"Mon"`) is also accepted
+ * for forward/backward compatibility — no consumer reads these fields.
+ */
+const PollRecurrenceDaySchema = z.union([
+	z.string(),
+	z.object({
+		value: z.string().optional(),
+		order: z.string().optional(),
+	}),
+]);
+
+const PollRecurrenceMonthSchema = z.union([
+	z.string(),
+	z.object({
+		value: z.string().optional(),
+		order: z.string().optional(),
+	}),
+]);
+
 /** Poll recurrence settings */
 const PollRecurrenceSchema = z
 	.object({
 		type: z.string(),
 		repeat: z.number().nullable(),
 		every: z.string().nullable(),
-		day: z.string().nullable(),
-		month: z.string().nullable(),
+		day: PollRecurrenceDaySchema.nullable(),
+		month: PollRecurrenceMonthSchema.nullable(),
 	})
 	.nullable();
 

--- a/tests/schemas/poll.test.ts
+++ b/tests/schemas/poll.test.ts
@@ -75,6 +75,95 @@ describe("PollSchema", () => {
 		expect(poll.users).toHaveLength(1);
 		expect(poll.users[0]?.username).toBe("jane");
 	});
+
+	test("#5: accepts weekly recurrence with object day", () => {
+		const poll = PollSchema.parse({
+			...samplePoll,
+			recurrence: { type: "weekly", repeat: 1, every: null, day: { value: "monday" }, month: null },
+		});
+		expect(poll.recurrence?.day).toEqual({ value: "monday" });
+	});
+
+	test("#5: accepts monthly recurrence with nth-of-weekday day object", () => {
+		const poll = PollSchema.parse({
+			...samplePoll,
+			recurrence: {
+				type: "monthly",
+				repeat: null,
+				every: null,
+				day: { order: "2nd", value: "wednesday" },
+				month: null,
+			},
+		});
+		expect(poll.recurrence?.day).toEqual({ order: "2nd", value: "wednesday" });
+	});
+
+	test("#5: accepts monthly recurrence with date-of-month day object", () => {
+		const poll = PollSchema.parse({
+			...samplePoll,
+			recurrence: {
+				type: "monthly",
+				repeat: null,
+				every: null,
+				day: { order: "15", value: "day" },
+				month: null,
+			},
+		});
+		expect(poll.recurrence?.day).toEqual({ order: "15", value: "day" });
+	});
+
+	test("#5: accepts quarterly recurrence with object month and day", () => {
+		const poll = PollSchema.parse({
+			...samplePoll,
+			recurrence: {
+				type: "quarterly",
+				repeat: null,
+				every: null,
+				day: { order: "3rd", value: "monday" },
+				month: { order: "1st" },
+			},
+		});
+		expect(poll.recurrence?.month).toEqual({ order: "1st" });
+		expect(poll.recurrence?.day).toEqual({ order: "3rd", value: "monday" });
+	});
+
+	test("#5: accepts yearly recurrence with object month and day", () => {
+		const poll = PollSchema.parse({
+			...samplePoll,
+			recurrence: {
+				type: "yearly",
+				repeat: null,
+				every: null,
+				day: { order: "1st", value: "monday" },
+				month: { value: "july" },
+			},
+		});
+		expect(poll.recurrence?.month).toEqual({ value: "july" });
+	});
+
+	test("#5: preserves legacy string day and month (backward compat)", () => {
+		const poll = PollSchema.parse({
+			...samplePoll,
+			recurrence: {
+				type: "monthly",
+				repeat: 1,
+				every: null,
+				day: "Mon",
+				month: "January",
+			},
+		});
+		expect(poll.recurrence?.day).toBe("Mon");
+		expect(poll.recurrence?.month).toBe("January");
+	});
+
+	test("#5: accepts null day and month inside a non-null recurrence", () => {
+		const poll = PollSchema.parse({
+			...samplePoll,
+			recurrence: { type: "once", repeat: null, every: null, day: null, month: null },
+		});
+		expect(poll.recurrence?.day).toBeNull();
+		expect(poll.recurrence?.month).toBeNull();
+	});
 });
 
 describe("PollListSchema", () => {
@@ -86,6 +175,25 @@ describe("PollListSchema", () => {
 	test("parses empty array", () => {
 		const polls = PollListSchema.parse([]);
 		expect(polls).toHaveLength(0);
+	});
+
+	test("#5: accepts list where recurrence.day and recurrence.month are objects", () => {
+		// Exact failure path from issue #5 — error was `0.recurrence.day`, `0.recurrence.month`.
+		const polls = PollListSchema.parse([
+			{
+				...samplePoll,
+				recurrence: {
+					type: "yearly",
+					repeat: null,
+					every: null,
+					day: { order: "1st", value: "monday" },
+					month: { value: "july" },
+				},
+			},
+		]);
+		expect(polls).toHaveLength(1);
+		expect(polls[0]?.recurrence?.day).toEqual({ order: "1st", value: "monday" });
+		expect(polls[0]?.recurrence?.month).toEqual({ value: "july" });
 	});
 });
 


### PR DESCRIPTION
## Summary
- `PollRecurrenceSchema` required `recurrence.day` and `recurrence.month` to be strings, so `geekbot poll list/get/create` aborted with `schema_validation_error` for any poll whose recurrence was not `type: "once"` — the API returns objects like `{ value: "monday" }`, `{ order: "2nd", value: "wednesday" }`, `{ order: "1st" }`, `{ value: "july" }` for weekly/monthly/quarterly/yearly/custom recurrences.
- Replaced both fields with `z.union([z.string(), z.object({ value?, order? })]).nullable()`. Legacy string form kept for backward compatibility; shapes drawn from the upstream poll-job-scheduler source. No downstream code reads these fields, so loosening is risk-free.
- Closes #5.

## Changes
- `src/schemas/poll.ts` — extracted `PollRecurrenceDaySchema` / `PollRecurrenceMonthSchema` as named unions, wired into `PollRecurrenceSchema`.
- `tests/schemas/poll.test.ts` — 8 regression tests: weekly, monthly (nth-of-weekday / date-of-month), quarterly, yearly, legacy string, nested-null, and a `PollListSchema` test that reproduces the exact `0.recurrence.day` / `0.recurrence.month` failure path from the bug report.

## Test plan
- [x] `bun test tests/schemas/poll.test.ts` — 21 pass / 0 fail, 100% line coverage of `poll.ts`
- [x] `bun test` — 596 pass / 0 fail across 52 files
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` — clean
- [x] `bun run src/cli/index.ts poll list` — returns real polls successfully (sanity only: this workspace has only `type: "once"` polls, so the object branches are covered by unit tests rather than the live call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)