### PR TITLE
feat: add OAuth login (PKCE + loopback) as auth flow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+# Pre-commit hook for geekbot-cli.
+# Mirrors the lint + typecheck gates in .github/workflows/ci.yml so
+# CI failures get caught locally before you push.
+#
+# Opt in: `git config core.hooksPath .githooks` (run once per clone).
+# Skip a single commit: `git commit --no-verify` (avoid as a habit).
+
+set -e
+
+if ! command -v bun >/dev/null 2>&1; then
+	echo "pre-commit: bun is not on PATH; skipping lint/typecheck." >&2
+	exit 0
+fi
+
+echo "pre-commit: bun run lint"
+bun run lint
+
+echo "pre-commit: bunx tsc --noEmit"
+bunx tsc --noEmit

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install the plugin from this repo's built-in marketplace — it bundles the CLI 
 Then run `/geekbot:geekbot-setup`. Claude will:
 
 1. Install the `geekbot` CLI globally via `npm install -g geekbot-cli` (if it isn't on your `$PATH`)
-2. Walk you through the `geekbot auth setup --api-key …` flow (you paste the key into **your own shell**, never into the conversation)
+2. Walk you through `geekbot auth login` (OAuth in your browser — no API key paste, token written to your OS keychain). Falls back to `geekbot auth setup --api-key …` if OAuth isn't available.
 3. Verify everything and report the final state
 
 The plugin ships three skills:
@@ -157,7 +157,7 @@ For first-time setup, ask in chat:
 run the geekbot setup
 ```
 
-— or handle it manually with `npm install -g geekbot-cli` and `geekbot auth setup --api-key <YOUR_KEY>` (key from https://app.geekbot.com/dashboard/api-webhooks).
+— or handle it manually with `npm install -g geekbot-cli` and `geekbot auth login` (browser OAuth), or `geekbot auth setup --api-key <YOUR_KEY>` (API key from https://app.geekbot.com/dashboard/api-webhooks).
 
 **Managing the marketplace:**
 
@@ -181,7 +181,7 @@ gemini extensions new geekbot --from geekbot-com/geekbot-cli
 
 Once linked, the skills become available. Invoke them with natural language (*"fetch my standups"*) — Gemini matches the skill's `description` frontmatter.
 
-> **Note:** Slash commands in Gemini CLI use TOML files under `commands/` (different from Claude Code / Codex). This extension does not ship slash-command TOMLs — install and auth are handled by running the CLI directly (`npm install -g geekbot-cli`, `geekbot auth setup --api-key …`) and day-to-day workflows are driven by the auto-invoked skill. Ask for it in plain English and Gemini will shell out to `geekbot`.
+> **Note:** Slash commands in Gemini CLI use TOML files under `commands/` (different from Claude Code / Codex). This extension does not ship slash-command TOMLs — install and auth are handled by running the CLI directly (`npm install -g geekbot-cli`, then `geekbot auth login` for browser OAuth or `geekbot auth setup --api-key …` for an API key) and day-to-day workflows are driven by the auto-invoked skill. Ask for it in plain English and Gemini will shell out to `geekbot`.
 
 ### Manual installation
 
@@ -207,11 +207,21 @@ geekbot --version
 
 #### 2. Authenticate
 
+Browser-based OAuth (recommended):
+
+```shell
+geekbot auth login
+```
+
+Opens your default browser, you approve in the Geekbot dashboard, and a short-lived `cli_*` token is written to your OS keychain — no API key paste, no shell history. Use `geekbot auth login --no-browser` on headless / WSL / SSH boxes; the CLI will print the authorize URL for you to open manually.
+
+API-key alternative (handy for CI or when OAuth isn't available):
+
 ```shell
 geekbot auth setup --api-key <YOUR_KEY>
 ```
 
-Grab the key at https://app.geekbot.com/dashboard/api-webhooks. It's stored in your OS keychain — no dotfiles, no plaintext.
+Grab the key at https://app.geekbot.com/dashboard/api-webhooks. Either flow stores credentials in your OS keychain — no dotfiles, no plaintext.
 
 #### 3. Register the skill with your AI agents
 
@@ -284,9 +294,25 @@ The CLI resolves API credentials using a three-level priority chain. The first s
 
 1. **`--api-key` flag** (highest priority) -- per-command override, useful for scripts and CI
 2. **`GEEKBOT_API_KEY` environment variable** -- session or shell-level credential
-3. **OS keychain** (lowest priority) -- persistent, secure storage via `geekbot auth setup`
+3. **OS keychain** (lowest priority) -- persistent, secure storage via `geekbot auth login` (OAuth) or `geekbot auth setup` (API key)
 
-### OS Keychain Storage
+### OAuth login (recommended)
+
+```shell
+geekbot auth login
+```
+
+Runs the OAuth 2.0 authorization-code flow with PKCE: the CLI starts a `127.0.0.1:<port>/callback` loopback listener, opens your default browser at `https://oauth.geekbot.com/v2/authorize?...`, and after you approve in the browser, exchanges the returned code for a short-lived `cli_*` token that is written to your OS keychain — same storage as the API-key flow. No secret is ever pasted into your terminal or shell history.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--no-browser` | -- | Print the authorize URL instead of trying to launch a browser (useful in WSL, SSH sessions, headless CI, or when piping the URL elsewhere) |
+| `--device-name <name>` | hostname | Friendly name shown on the token in the dashboard, so you can revoke it later |
+| `--ttl-days <days>` | `30` | CLI token lifetime. Allowed values: `7`, `30`, `90`, `180`, `365` |
+
+Override the OAuth endpoint via `GEEKBOT_OAUTH_BASE_URL` (must be `https://`); defaults to `https://oauth.geekbot.com`.
+
+### API-key setup (alternative)
 
 The CLI uses [`@napi-rs/keyring`](https://github.com/nicola-nicolo/keyring) to store your API key in the platform-native credential store:
 
@@ -484,6 +510,7 @@ Polls are only available for Slack-connected teams. Non-Slack teams will receive
 
 | Subcommand | Syntax | Description |
 |------------|--------|-------------|
+| `login` | `geekbot auth login [--no-browser] [--device-name <name>] [--ttl-days <days>]` | Sign in via OAuth (PKCE + loopback redirect) |
 | `setup` | `geekbot auth setup [--api-key <key>]` | Interactively configure and store API key |
 | `status` | `geekbot auth status` | Verify stored credentials work |
 | `remove` | `geekbot auth remove` | Remove stored API key from OS keychain |
@@ -723,6 +750,16 @@ bun run format
 ```shell
 bun run check
 ```
+
+### Pre-commit hook
+
+The repo ships a hook at `.githooks/pre-commit` that runs `bun run lint` and `bunx tsc --noEmit` — the same two gates CI blocks PRs on. Opt in once per clone:
+
+```shell
+git config core.hooksPath .githooks
+```
+
+To skip the hook for a single commit (avoid as a habit): `git commit --no-verify`.
 
 ### Integration tests
 

--- a/skills/geekbot-run/SKILL.md
+++ b/skills/geekbot-run/SKILL.md
@@ -31,9 +31,12 @@ Run `check-cli.sh` on first invocation. If it fails:
 - **CLI not found**: Install via `npm install -g geekbot-cli` (requires
   Bun >= 1.3.5 runtime). Note: `npx geekbot-cli` also requires Bun on
   PATH — it is not a Node.js fallback.
-- **Auth not configured**: Guide the user to run `geekbot auth setup`
-  which stores the API key in the OS keychain. Alternatively they can
-  set `GEEKBOT_API_KEY` as an environment variable.
+- **Auth not configured**: Guide the user to run `geekbot auth login`,
+  which uses the OAuth 2.1 authorization-code + PKCE flow with a
+  `http://127.0.0.1:<port>/callback` loopback redirect and writes the
+  resulting `cli_*` token to the OS keychain. As a fallback they can use
+  `geekbot auth setup --api-key <KEY>` with a dashboard API key, or set
+  `GEEKBOT_API_KEY` as an environment variable.
 
 Do not attempt any Geekbot operation until both checks pass.
 
@@ -238,7 +241,7 @@ exit code.
 |-----------|---------|--------------|
 | 0 | Success | Proceed normally |
 | 3 | Not found | Parse `error.suggestion` — it lists valid IDs. Offer them to the user. |
-| 4 | Auth failed | Guide user through `geekbot auth setup`. Do not retry. |
+| 4 | Auth failed | Guide user through `geekbot auth login` (or `geekbot auth setup --api-key` as fallback). Do not retry. |
 | 5 | Forbidden | Explain permission issue. The user may need admin access. |
 | 6 | Validation | Show `error.message`, help the user fix the input. |
 | 7 | Network | If `error.retryable` is true, retry once after 2s silently. If it fails again, report. |
@@ -253,7 +256,8 @@ exit code.
 - **Inventing report answers** — if the user didn't provide enough context
   for a question, ask. Never guess or fabricate.
 - **Retrying auth errors** — exit code 4 is never transient. Guide the user
-  to `geekbot auth setup` instead.
+  to `geekbot auth login` (or `geekbot auth setup --api-key` as fallback)
+  instead.
 - **Skipping confirmation for deletes** — always show what will be deleted
   and get explicit approval, even if it feels obvious.
 - **Dumping raw JSON** — format output as tables, summaries, or narratives.

--- a/skills/geekbot-setup/SKILL.md
+++ b/skills/geekbot-setup/SKILL.md
@@ -40,24 +40,87 @@ Goal: get the user fully ready — CLI installed, CLI authenticated, and a clear
    - If `data.authenticated == true` → skip to step 6.
    - Otherwise → step 5.
 
-5. **Walk the user through auth — do NOT handle the API key in-session.** Tell them:
+5. **Authenticate via OAuth — you drive `geekbot auth login` yourself.**
+   Do NOT tell the user to run anything in their shell. Do NOT ask for an
+   API key. The CLI's loopback flow only exposes a public authorize URL
+   (no secrets), and writes the resulting `cli_*` token to the user's OS
+   keychain on their own machine when the flow completes.
 
-   - Get your API key from https://app.geekbot.com/dashboard/api-webhooks
-   - Then run (in your own shell, not here): `! geekbot auth setup --api-key <YOUR_KEY>`
-   - The `!` prefix runs it in your shell so the key lands in the OS keychain, not the conversation transcript.
+   **Procedure:**
 
-   After the user reports back, re-run `geekbot auth status` to confirm.
+   a. **Start the login command in the background.** Use Bash with
+      `run_in_background: true` so you can read the verification URL while
+      the CLI waits on its loopback listener. Always pass `--no-browser` —
+      you can't pick the user's browser for them, especially on WSL where
+      `xdg-open` would launch the Linux default rather than the browser
+      that holds the user's Geekbot dashboard session.
+
+      ```bash
+      geekbot auth login --no-browser --ttl-days 30
+      ```
+
+   b. **Capture the authorize URL.** Call `BashOutput` on the background
+      shell once, then again a second later if needed, until stderr
+      contains a line that starts with `https://` and a URL pointing at
+      `/v2/authorize?...`. The CLI prints a block like:
+
+      ```
+      Listening on http://127.0.0.1:<port>/callback for the OAuth callback…
+      Open this URL in a browser to sign in:
+        https://oauth.geekbot.com/v2/authorize?...&state=...&code_challenge=...
+      Only open it ONCE — the state is single-use.
+      ```
+
+   c. **Show the URL to the user, exactly once.** Reply with something
+      like:
+
+      > To finish signing in to Geekbot, open this URL in any browser
+      > you're already logged into your dashboard with:
+      >
+      >   `<URL>`
+      >
+      > Only open it once — the OAuth `state` is single-use, so a second
+      > browser will fail.
+
+   d. **Wait for the command to exit.** Continue calling `BashOutput`
+      periodically until the background shell completes. Don't pre-empt
+      with a timeout shorter than the CLI's own (~5 min).
+
+   e. **Parse the outcome:**
+      - **Exit 0** — stdout contains a JSON envelope of shape
+        `{"ok": true, "data": {"authenticated": true, "method": "oauth_loopback", "username": ..., "email": ...}}`.
+        Proceed to step 6.
+      - **Non-zero exit** — stdout/stderr contains an error envelope.
+        Common codes:
+        - `oauth_callback_timeout` — user didn't click in time. Offer to
+          retry from step 5a.
+        - `oauth_access_denied` — user clicked "Cancel" at the IdP.
+        - `oauth_state_mismatch` / `oauth_invalid_request` — they opened
+          the URL twice; retry, remind them once is enough.
+        - `oauth_invalid_client` — the CLI's `client_id` isn't registered
+          on the auth server; this is an environment issue, not a user
+          one — report it and stop.
+
+   **Fallback only — do NOT suggest unless OAuth login fails twice in a row
+   or the user explicitly asks for it.** Long-lived dashboard API keys
+   still work via:
+   - Get the key from https://app.geekbot.com/dashboard/api-webhooks
+   - Then run: `! geekbot auth setup --api-key <YOUR_KEY>`
 
 6. **Report final state.** Example:
 
    ```
    geekbot CLI: installed (v0.2.4)
-   Auth:        authenticated as sabpap@geekbot.com
+   Auth:        authenticated as sabpap@geekbot.com (oauth_loopback)
    Next:        you're ready — try "fetch my standups"
    ```
 
-   If auth is still missing, end with "run `/geekbot:geekbot-setup` again after completing the `geekbot auth setup` step."
+   If auth is still missing, end with "run `/geekbot:geekbot-setup` again after completing the `geekbot auth login` step."
 
-## Why not handle the API key directly
+## Why not handle the credential directly
 
-API keys are secrets. Pasting one into the conversation puts it in the transcript and any logs/exports that derive from it. The CLI's `auth setup` command writes to the OS keychain — that's where it belongs. Once stored, every later `geekbot …` call authenticates silently.
+API keys and CLI tokens are secrets. Pasting one into the conversation puts it
+in the transcript and any logs/exports derived from it. The CLI's `auth login`
+flow keeps the token on the user's machine end-to-end: the auth server hands
+it to the local CLI, which writes it straight to the OS keychain. Once stored,
+every later `geekbot …` call authenticates silently.

--- a/src/auth/oauth-loopback.ts
+++ b/src/auth/oauth-loopback.ts
@@ -1,0 +1,467 @@
+import { createHash, randomBytes } from "node:crypto";
+import { hostname } from "node:os";
+import { CliError } from "../errors/cli-error.ts";
+import { ExitCode } from "../errors/exit-codes.ts";
+import {
+	APP_VERSION,
+	OAUTH_BASE_URL,
+	OAUTH_CLI_ALLOWED_TTL_DAYS,
+	OAUTH_CLIENT_ID,
+	type OAuthCliTtlDays,
+} from "../utils/constants.ts";
+
+const USER_AGENT = `geekbot-skill-cli/${APP_VERSION}`;
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface PkcePair {
+	verifier: string;
+	challenge: string;
+	method: "S256";
+}
+
+export interface TokenResponse {
+	access_token: string;
+	token_type: string;
+	expires_in: number | null;
+	scope: string;
+}
+
+export interface CallbackResult {
+	code: string;
+	state: string;
+}
+
+export interface LoopbackServer {
+	port: number;
+	redirectUri: string;
+	awaitCallback: (expectedState: string, timeoutMs?: number) => Promise<CallbackResult>;
+	close: () => Promise<void>;
+}
+
+export interface LoopbackDeps {
+	fetchImpl?: typeof globalThis.fetch;
+	openBrowser?: (url: string) => Promise<void> | void;
+	startServer?: () => Promise<LoopbackServer>;
+	baseUrl?: string;
+	clientId?: string;
+	prompt?: (text: string) => void;
+	debug?: boolean;
+}
+
+export interface RunLoopbackOptions {
+	deviceName?: string;
+	ttlDays?: OAuthCliTtlDays;
+	scope?: string;
+	noBrowser?: boolean;
+	timeoutMs?: number;
+}
+
+// ── PKCE helpers ─────────────────────────────────────────────────────
+
+function base64url(buf: Buffer): string {
+	return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function generatePkce(): PkcePair {
+	// 32 bytes -> 43-char base64url verifier, well within RFC 7636's 43-128 range.
+	const verifier = base64url(randomBytes(32));
+	const challenge = base64url(createHash("sha256").update(verifier).digest());
+	return { verifier, challenge, method: "S256" };
+}
+
+export function generateState(): string {
+	return base64url(randomBytes(16));
+}
+
+// ── URL building ─────────────────────────────────────────────────────
+
+export interface AuthorizeUrlParams {
+	baseUrl?: string;
+	clientId?: string;
+	redirectUri: string;
+	state: string;
+	codeChallenge: string;
+	scope: string;
+	deviceName: string;
+	ttlDays: OAuthCliTtlDays;
+}
+
+export function buildAuthorizeUrl(params: AuthorizeUrlParams): string {
+	const base = (params.baseUrl ?? OAUTH_BASE_URL).replace(/\/+$/, "");
+	const query = new URLSearchParams({
+		response_type: "code",
+		client_id: params.clientId ?? OAUTH_CLIENT_ID,
+		redirect_uri: params.redirectUri,
+		state: params.state,
+		code_challenge: params.codeChallenge,
+		code_challenge_method: "S256",
+		scope: params.scope,
+		device_name: params.deviceName,
+		ttl_days: String(params.ttlDays),
+	});
+	return `${base}/v2/authorize?${query.toString()}`;
+}
+
+// ── Token exchange ───────────────────────────────────────────────────
+
+export interface ExchangeCodeParams {
+	code: string;
+	codeVerifier: string;
+	redirectUri: string;
+	baseUrl?: string;
+	clientId?: string;
+	fetchImpl?: typeof globalThis.fetch;
+}
+
+export async function exchangeCodeForToken(params: ExchangeCodeParams): Promise<TokenResponse> {
+	const _fetch = params.fetchImpl ?? globalThis.fetch;
+	const base = (params.baseUrl ?? OAUTH_BASE_URL).replace(/\/+$/, "");
+	const body = new URLSearchParams({
+		grant_type: "authorization_code",
+		code: params.code,
+		redirect_uri: params.redirectUri,
+		client_id: params.clientId ?? OAUTH_CLIENT_ID,
+		code_verifier: params.codeVerifier,
+	});
+
+	let response: Response;
+	try {
+		response = await _fetch(`${base}/v2/token`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				Accept: "application/json",
+				"User-Agent": USER_AGENT,
+			},
+			body: body.toString(),
+		});
+	} catch (error) {
+		throw new CliError(
+			`Network error contacting OAuth server: ${error instanceof Error ? error.message : String(error)}`,
+			"network_error",
+			ExitCode.NETWORK,
+			true,
+			"Check your internet connection and try again.",
+		);
+	}
+
+	const payload = await readJson(response);
+
+	if (!response.ok) {
+		throw oauthError(payload, response.status);
+	}
+
+	if (
+		!isObject(payload) ||
+		typeof payload.access_token !== "string" ||
+		payload.access_token === ""
+	) {
+		throw new CliError(
+			"OAuth server returned an invalid token response.",
+			"oauth_invalid_response",
+			ExitCode.API_ERROR,
+			false,
+		);
+	}
+
+	return {
+		access_token: payload.access_token,
+		token_type: typeof payload.token_type === "string" ? payload.token_type : "Bearer",
+		expires_in: typeof payload.expires_in === "number" ? payload.expires_in : null,
+		scope: typeof payload.scope === "string" ? payload.scope : "cli",
+	};
+}
+
+// ── Loopback HTTP server ─────────────────────────────────────────────
+
+const SUCCESS_PAGE = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Geekbot CLI</title>
+<style>body{font-family:system-ui;text-align:center;padding:48px;color:#222}
+.box{max-width:480px;margin:auto;padding:24px;border:1px solid #eee;border-radius:8px}
+h1{margin:0 0 8px;font-size:20px}</style></head>
+<body><div class="box"><h1>✓ Signed in to Geekbot CLI</h1>
+<p>You can close this tab and return to your terminal.</p></div></body></html>`;
+
+const ERROR_PAGE = (msg: string): string =>
+	`<!doctype html><html><head><meta charset="utf-8"><title>Geekbot CLI</title></head>
+<body style="font-family:system-ui;padding:48px"><h1>Sign-in failed</h1>
+<p>${msg.replace(/[<>&]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;" })[c] ?? c)}</p>
+<p>Return to your terminal for details.</p></body></html>`;
+
+/**
+ * Starts a loopback HTTP listener on 127.0.0.1:<random port> and resolves
+ * with the redirect_uri + a one-shot promise for the callback parameters.
+ *
+ * The server handles a single GET /callback and then closes. Subsequent or
+ * mismatched requests get a 404.
+ */
+export async function startLoopbackServer(): Promise<LoopbackServer> {
+	let resolveCallback: (value: CallbackResult) => void;
+	let rejectCallback: (err: unknown) => void;
+	const callbackPromise = new Promise<CallbackResult>((res, rej) => {
+		resolveCallback = res;
+		rejectCallback = rej;
+	});
+	let consumed = false;
+
+	const server = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0,
+		fetch(req) {
+			const url = new URL(req.url);
+			if (url.pathname !== "/callback") {
+				return new Response("Not found", { status: 404 });
+			}
+			if (consumed) {
+				return new Response("Already handled", { status: 410 });
+			}
+			const error = url.searchParams.get("error");
+			const code = url.searchParams.get("code");
+			const state = url.searchParams.get("state");
+
+			if (error) {
+				consumed = true;
+				const description = url.searchParams.get("error_description") ?? "";
+				rejectCallback(
+					new CliError(
+						description ? `${error}: ${description}` : error,
+						`oauth_${error}`,
+						ExitCode.AUTH,
+						false,
+					),
+				);
+				return new Response(ERROR_PAGE(`${error}${description ? `: ${description}` : ""}`), {
+					status: 400,
+					headers: { "Content-Type": "text/html; charset=utf-8" },
+				});
+			}
+
+			if (!code || !state) {
+				consumed = true;
+				rejectCallback(
+					new CliError(
+						"OAuth callback missing code or state",
+						"oauth_invalid_callback",
+						ExitCode.AUTH,
+						false,
+					),
+				);
+				return new Response(ERROR_PAGE("Missing code or state in callback."), {
+					status: 400,
+					headers: { "Content-Type": "text/html; charset=utf-8" },
+				});
+			}
+
+			consumed = true;
+			resolveCallback({ code, state });
+			return new Response(SUCCESS_PAGE, {
+				status: 200,
+				headers: { "Content-Type": "text/html; charset=utf-8" },
+			});
+		},
+	});
+
+	const port = server.port as number;
+	const redirectUri = `http://127.0.0.1:${port}/callback`;
+
+	const awaitCallback = async (
+		expectedState: string,
+		timeoutMs: number = DEFAULT_TIMEOUT_MS,
+	): Promise<CallbackResult> => {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		try {
+			const result = await Promise.race([
+				callbackPromise,
+				new Promise<never>((_resolve, reject) => {
+					timer = setTimeout(() => {
+						reject(
+							new CliError(
+								"Timed out waiting for OAuth callback.",
+								"oauth_callback_timeout",
+								ExitCode.AUTH,
+								false,
+								"Restart `geekbot auth login` and complete the sign-in within a few minutes.",
+							),
+						);
+					}, timeoutMs);
+				}),
+			]);
+			if (result.state !== expectedState) {
+				throw new CliError(
+					"OAuth callback state did not match.",
+					"oauth_state_mismatch",
+					ExitCode.AUTH,
+					false,
+					"The login response did not match this CLI session. Run `geekbot auth login` again.",
+				);
+			}
+			return result;
+		} finally {
+			if (timer) clearTimeout(timer);
+		}
+	};
+
+	return {
+		port,
+		redirectUri,
+		awaitCallback,
+		close: async () => {
+			server.stop(true);
+		},
+	};
+}
+
+// ── Browser opener ───────────────────────────────────────────────────
+
+export async function openInBrowser(url: string): Promise<void> {
+	const platform = process.platform;
+	let command: string;
+	let args: string[];
+	if (platform === "darwin") {
+		command = "open";
+		args = [url];
+	} else if (platform === "win32") {
+		command = "cmd";
+		args = ["/c", "start", "", url];
+	} else {
+		command = "xdg-open";
+		args = [url];
+	}
+	const proc = Bun.spawn([command, ...args], {
+		stdout: "ignore",
+		stderr: "ignore",
+		stdin: "ignore",
+	});
+	proc.unref?.();
+}
+
+// ── Orchestrator ─────────────────────────────────────────────────────
+
+export async function runLoopbackFlow(
+	options: RunLoopbackOptions,
+	deps: LoopbackDeps = {},
+): Promise<TokenResponse> {
+	const ttlDays = (options.ttlDays ?? 30) as OAuthCliTtlDays;
+	if (!OAUTH_CLI_ALLOWED_TTL_DAYS.includes(ttlDays)) {
+		throw new CliError(
+			`ttl_days must be one of ${OAUTH_CLI_ALLOWED_TTL_DAYS.join(", ")}`,
+			"validation_error",
+			ExitCode.VALIDATION,
+			false,
+		);
+	}
+	const deviceName = (options.deviceName ?? safeHostname()).slice(0, 128);
+	const scope = options.scope ?? "cli";
+	const baseUrl = deps.baseUrl ?? OAUTH_BASE_URL;
+	const clientId = deps.clientId ?? OAUTH_CLIENT_ID;
+	const writePrompt =
+		deps.prompt ??
+		((text: string) => {
+			process.stderr.write(text);
+		});
+
+	const start = deps.startServer ?? startLoopbackServer;
+	const server = await start();
+
+	try {
+		const pkce = generatePkce();
+		const state = generateState();
+		const authUrl = buildAuthorizeUrl({
+			baseUrl,
+			clientId,
+			redirectUri: server.redirectUri,
+			state,
+			codeChallenge: pkce.challenge,
+			scope,
+			deviceName,
+			ttlDays,
+		});
+
+		writePrompt(`\nListening on ${server.redirectUri} for the OAuth callback…\n`);
+
+		let browserOpened = false;
+		if (!options.noBrowser) {
+			try {
+				if (deps.openBrowser) {
+					await deps.openBrowser(authUrl);
+				} else {
+					await openInBrowser(authUrl);
+				}
+				browserOpened = true;
+			} catch {
+				// Fall through to prompting the user with the URL.
+			}
+		}
+
+		if (browserOpened) {
+			writePrompt(
+				"Opened your browser to sign in. Complete the flow there — do NOT open this URL\nin a second browser (the state is single-use).\n\n",
+			);
+		} else {
+			writePrompt(
+				[
+					"Open this URL in a browser to sign in:",
+					`  ${authUrl}`,
+					"",
+					"Only open it ONCE — the state is single-use.",
+					"",
+				].join("\n"),
+			);
+		}
+
+		const { code } = await server.awaitCallback(state, options.timeoutMs);
+
+		return await exchangeCodeForToken({
+			code,
+			codeVerifier: pkce.verifier,
+			redirectUri: server.redirectUri,
+			baseUrl,
+			clientId,
+			fetchImpl: deps.fetchImpl,
+		});
+	} finally {
+		await server.close();
+	}
+}
+
+function safeHostname(): string {
+	try {
+		const h = hostname();
+		return h && h.trim() !== "" ? h : "geekbot-cli";
+	} catch {
+		return "geekbot-cli";
+	}
+}
+
+function oauthError(payload: unknown, status: number): CliError {
+	const error =
+		isObject(payload) && typeof payload.error === "string" ? payload.error : `HTTP ${status}`;
+	const description =
+		isObject(payload) && typeof payload.error_description === "string"
+			? payload.error_description
+			: "";
+	const message = description ? `${error}: ${description}` : error;
+	const exitCode = status === 401 || status === 403 ? ExitCode.AUTH : ExitCode.API_ERROR;
+	return new CliError(
+		`OAuth error — ${message}`,
+		`oauth_${error}`,
+		exitCode,
+		status >= 500,
+		undefined,
+		{ status },
+	);
+}
+
+async function readJson(response: Response): Promise<unknown> {
+	const text = await response.text();
+	if (text === "") return {};
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/auth/oauth-loopback.ts
+++ b/src/auth/oauth-loopback.ts
@@ -182,10 +182,25 @@ h1{margin:0 0 8px;font-size:20px}</style></head>
 <body><div class="box"><h1>✓ Signed in to Geekbot CLI</h1>
 <p>You can close this tab and return to your terminal.</p></div></body></html>`;
 
+function escapeHtml(s: string): string {
+	return s.replace(/[<>&]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;" })[c] ?? c);
+}
+
+const PLAN_NOT_ALLOWED_PAGE = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Geekbot CLI</title>
+<style>body{font-family:system-ui;text-align:center;padding:48px;color:#222}
+.box{max-width:520px;margin:auto;padding:24px;border:1px solid #eee;border-radius:8px}
+h1{margin:0 0 8px;font-size:20px}
+a.btn{display:inline-block;margin-top:16px;padding:10px 18px;background:#3578e5;color:#fff;text-decoration:none;border-radius:6px}</style></head>
+<body><div class="box"><h1>API access not available on this plan</h1>
+<p>Your current Geekbot plan does not include API access. Upgrade your plan to use the Geekbot CLI.</p>
+<a class="btn" href="https://geekbot.com/pricing" target="_blank" rel="noopener">View pricing</a>
+<p style="margin-top:24px;color:#666">You can close this tab and return to your terminal.</p></div></body></html>`;
+
 const ERROR_PAGE = (msg: string): string =>
 	`<!doctype html><html><head><meta charset="utf-8"><title>Geekbot CLI</title></head>
 <body style="font-family:system-ui;padding:48px"><h1>Sign-in failed</h1>
-<p>${msg.replace(/[<>&]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;" })[c] ?? c)}</p>
+<p>${escapeHtml(msg)}</p>
 <p>Return to your terminal for details.</p></body></html>`;
 
 /**
@@ -222,15 +237,12 @@ export async function startLoopbackServer(): Promise<LoopbackServer> {
 			if (error) {
 				consumed = true;
 				const description = url.searchParams.get("error_description") ?? "";
-				rejectCallback(
-					new CliError(
-						description ? `${error}: ${description}` : error,
-						`oauth_${error}`,
-						ExitCode.AUTH,
-						false,
-					),
-				);
-				return new Response(ERROR_PAGE(`${error}${description ? `: ${description}` : ""}`), {
+				rejectCallback(mapOauthError(error, description));
+				const body =
+					description === "plan_does_not_allow_api_access"
+						? PLAN_NOT_ALLOWED_PAGE
+						: ERROR_PAGE(`${error}${description ? `: ${description}` : ""}`);
+				return new Response(body, {
 					status: 400,
 					headers: { "Content-Type": "text/html; charset=utf-8" },
 				});
@@ -306,6 +318,14 @@ export async function startLoopbackServer(): Promise<LoopbackServer> {
 		redirectUri,
 		awaitCallback,
 		close: async () => {
+			// Graceful: wait for the in-flight response (success or error HTML
+			// page) to flush before closing the listening socket. On the error
+			// path the rejection schedules close() in the same microtask the
+			// response was queued, and abrupt close races the response —
+			// browser sees ERR_CONNECTION_REFUSED. Force-close after 2s in case
+			// a client never reads.
+			const stopped = server.stop();
+			await Promise.race([stopped, new Promise<void>((resolve) => setTimeout(resolve, 2000))]);
 			server.stop(true);
 		},
 	};
@@ -440,6 +460,9 @@ function oauthError(payload: unknown, status: number): CliError {
 		isObject(payload) && typeof payload.error_description === "string"
 			? payload.error_description
 			: "";
+	if (description === "plan_does_not_allow_api_access") {
+		return planDoesNotAllowApiAccessError();
+	}
 	const message = description ? `${error}: ${description}` : error;
 	const exitCode = status === 401 || status === 403 ? ExitCode.AUTH : ExitCode.API_ERROR;
 	return new CliError(
@@ -449,6 +472,34 @@ function oauthError(payload: unknown, status: number): CliError {
 		status >= 500,
 		undefined,
 		{ status },
+	);
+}
+
+/**
+ * Translates an OAuth redirect-style error (error + error_description query
+ * params on the loopback callback) into a CliError. The api signals plan-based
+ * rejection with error_description=plan_does_not_allow_api_access; surface
+ * that as a clear, non-retryable error instead of a generic OAuth failure.
+ */
+function mapOauthError(error: string, description: string): CliError {
+	if (description === "plan_does_not_allow_api_access") {
+		return planDoesNotAllowApiAccessError();
+	}
+	return new CliError(
+		description ? `${error}: ${description}` : error,
+		`oauth_${error}`,
+		ExitCode.AUTH,
+		false,
+	);
+}
+
+function planDoesNotAllowApiAccessError(): CliError {
+	return new CliError(
+		"Your Geekbot plan does not allow API access.",
+		"plan_does_not_allow_api_access",
+		ExitCode.FORBIDDEN,
+		false,
+		"Upgrade your plan to enable API access: https://geekbot.com/pricing",
 	);
 }
 

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { handleError } from "../../errors/error-handler.ts";
 import {
+	handleAuthLogin,
 	handleAuthRemove,
 	handleAuthSetup,
 	handleAuthStatus,
@@ -21,6 +22,38 @@ export function createAuthCommand(): Command {
 			const globalOpts = getGlobalOptions(this);
 			try {
 				await handleAuthSetup({ apiKey: globalOpts.apiKey }, globalOpts);
+			} catch (error) {
+				handleError(error, globalOpts.debug);
+			}
+		});
+
+	auth
+		.command("login")
+		.description("Sign in via OAuth (authorization code + PKCE + loopback redirect)")
+		.option("--no-browser", "Do not try to open the authorize URL in a browser")
+		.option("--device-name <name>", "Friendly name for this device (default: hostname)")
+		.option(
+			"--ttl-days <days>",
+			"CLI token lifetime in days (7, 30, 90, 180, or 365)",
+			(value) => Number.parseInt(value, 10),
+			30,
+		)
+		.addHelpText(
+			"after",
+			"\nExamples:\n  geekbot auth login\n  geekbot auth login --no-browser\n  geekbot auth login --device-name laptop --ttl-days 90",
+		)
+		.action(async function (this: Command) {
+			const globalOpts = getGlobalOptions(this);
+			const opts = this.opts<{ browser: boolean; deviceName?: string; ttlDays: number }>();
+			try {
+				await handleAuthLogin(
+					{
+						noBrowser: !opts.browser,
+						deviceName: opts.deviceName,
+						ttlDays: opts.ttlDays as 7 | 30 | 90 | 180 | 365,
+					},
+					globalOpts,
+				);
 			} catch (error) {
 				handleError(error, globalOpts.debug);
 			}

--- a/src/handlers/auth-handlers.ts
+++ b/src/handlers/auth-handlers.ts
@@ -1,4 +1,5 @@
 import { deleteKeychainKey, getKeychainKey, setKeychainKey } from "../auth/keychain.ts";
+import { type LoopbackDeps, runLoopbackFlow } from "../auth/oauth-loopback.ts";
 import { resolveCredential } from "../auth/resolver.ts";
 import type { GlobalOptions } from "../cli/globals.ts";
 import { CliError } from "../errors/cli-error.ts";
@@ -7,11 +8,25 @@ import { createHttpClient } from "../http/client.ts";
 import { success } from "../output/envelope.ts";
 import { writeOutput } from "../output/formatter.ts";
 import { MeResponseSchema } from "../schemas/user.ts";
+import type { OAuthCliTtlDays } from "../utils/constants.ts";
 
 // ── Option Interfaces ─────────────────────────────────────────────────
 
 export interface AuthSetupOptions {
 	apiKey?: string;
+}
+
+export interface AuthLoginOptions {
+	/** Skip the browser-open attempt — used in tests and headless agents. */
+	noBrowser?: boolean;
+	/** Friendly name shown next to the issued CLI token. Defaults to hostname. */
+	deviceName?: string;
+	/** Token lifetime in days. Must be one of 7, 30, 90, 180, 365. */
+	ttlDays?: OAuthCliTtlDays;
+	/** Override callback wait timeout (ms). */
+	timeoutMs?: number;
+	/** Hook for tests to mock fetch / server / browser opener / prompt. */
+	loopback?: LoopbackDeps;
 }
 
 // ── Handlers ──────────────────────────────────────────────────────────
@@ -92,6 +107,64 @@ export async function handleAuthSetup(
 			authenticated: true,
 			username: meResponse.user.username,
 			email: meResponse.user.email,
+		}),
+	);
+}
+
+/**
+ * Handle `geekbot auth login` command.
+ *
+ * Runs the OAuth 2.1 authorization-code + PKCE flow with a loopback redirect:
+ *   1. Start a 127.0.0.1 HTTP listener on a random port
+ *   2. Open the browser at /v2/authorize?...&redirect_uri=http://127.0.0.1:<port>/callback
+ *   3. Wait for the callback containing { code, state }, validate state, exchange code → cli_* token
+ *   4. Verify the token via GET /v1/me, then store it in the OS keychain
+ */
+export async function handleAuthLogin(
+	options: AuthLoginOptions,
+	globalOpts: GlobalOptions,
+): Promise<void> {
+	const token = await runLoopbackFlow(
+		{
+			noBrowser: options.noBrowser,
+			deviceName: options.deviceName,
+			ttlDays: options.ttlDays,
+			timeoutMs: options.timeoutMs,
+		},
+		{ ...options.loopback, debug: globalOpts.debug },
+	);
+
+	// Verify the token works against the api before persisting it.
+	const client = createHttpClient(token.access_token, { debug: globalOpts.debug });
+	const raw = await client.get<unknown>("/v1/me");
+	const meResponse = MeResponseSchema.parse(raw);
+
+	const existing = getKeychainKey();
+	if (existing) {
+		process.stderr.write("Replacing existing API key in keychain\n");
+	}
+
+	try {
+		setKeychainKey(token.access_token);
+	} catch {
+		throw new CliError(
+			"Failed to store CLI token in OS keychain.",
+			"keychain_unavailable",
+			ExitCode.GENERAL,
+			false,
+			'OS keychain may be unavailable. Use GEEKBOT_API_KEY environment variable instead: export GEEKBOT_API_KEY="your-token"',
+		);
+	}
+
+	writeOutput(
+		success({
+			authenticated: true,
+			method: "oauth_loopback",
+			username: meResponse.user.username,
+			email: meResponse.user.email,
+			token_type: token.token_type,
+			scope: token.scope,
+			expires_in: token.expires_in,
 		}),
 	);
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -21,4 +21,26 @@ export function resolveApiBaseUrl(envValue?: string): string {
 	return envValue;
 }
 
+export function resolveOAuthBaseUrl(envValue?: string): string {
+	if (envValue === undefined) {
+		return "https://oauth.geekbot.com";
+	}
+	if (!envValue.startsWith("https://")) {
+		throw new CliError(
+			"GEEKBOT_OAUTH_BASE_URL must use HTTPS to prevent token interception.",
+			"validation_error",
+			ExitCode.VALIDATION,
+			false,
+			"Set GEEKBOT_OAUTH_BASE_URL to an https:// URL.",
+		);
+	}
+	return envValue;
+}
+
 export const API_BASE_URL = resolveApiBaseUrl(process.env.GEEKBOT_API_BASE_URL);
+export const OAUTH_BASE_URL = resolveOAuthBaseUrl(process.env.GEEKBOT_OAUTH_BASE_URL);
+export const OAUTH_CLIENT_ID = "geekbot-cli";
+
+/** Allowed CLI token lifetimes (days). Mirrors the auth server's whitelist. */
+export const OAUTH_CLI_ALLOWED_TTL_DAYS = [7, 30, 90, 180, 365] as const;
+export type OAuthCliTtlDays = (typeof OAUTH_CLI_ALLOWED_TTL_DAYS)[number];

--- a/tests/auth/oauth-loopback.test.ts
+++ b/tests/auth/oauth-loopback.test.ts
@@ -10,6 +10,7 @@ import {
 	startLoopbackServer,
 } from "../../src/auth/oauth-loopback.ts";
 import { CliError } from "../../src/errors/cli-error.ts";
+import { ExitCode } from "../../src/errors/exit-codes.ts";
 
 const BASE = "https://oauth.test.geekbot.com";
 const CLIENT_ID = "geekbot-cli";
@@ -252,6 +253,29 @@ describe("startLoopbackServer", () => {
 		}
 	});
 
+	test("plan_does_not_allow_api_access maps to a forbidden CliError and serves the upgrade page", async () => {
+		const server = await startLoopbackServer();
+		try {
+			const callback = server.awaitCallback("s", 5000).catch((e) => e);
+			const res = await fetch(
+				`${server.redirectUri}?error=access_denied&error_description=plan_does_not_allow_api_access&state=s`,
+			);
+			expect(res.status).toBe(400);
+			const html = await res.text();
+			expect(html).toContain("API access not available on this plan");
+			expect(html).toContain("https://geekbot.com/pricing");
+			expect(html).not.toContain("plan_does_not_allow_api_access");
+
+			const e = await callback;
+			expect(e).toBeInstanceOf(CliError);
+			expect((e as CliError).code).toBe("plan_does_not_allow_api_access");
+			expect((e as CliError).exitCode).toBe(ExitCode.FORBIDDEN);
+			expect((e as CliError).suggestion).toContain("Upgrade");
+		} finally {
+			await server.close();
+		}
+	});
+
 	test("non-/callback paths return 404", async () => {
 		const server = await startLoopbackServer();
 		try {
@@ -274,6 +298,25 @@ describe("startLoopbackServer", () => {
 		} finally {
 			await server.close();
 		}
+	});
+
+	test("close() right after rejection still flushes the error HTML to the client", async () => {
+		// Regression: the runLoopbackFlow finally{} block calls close() in the
+		// same microtask as the error rejection. Abrupt server.stop(true) used
+		// to abort the in-flight response and the browser saw
+		// ERR_CONNECTION_REFUSED instead of our upgrade page.
+		const server = await startLoopbackServer();
+		const fetchPromise = fetch(
+			`${server.redirectUri}?error=access_denied&error_description=plan_does_not_allow_api_access&state=s`,
+		);
+		const callbackErr = server.awaitCallback("s", 5000).catch((e) => e);
+		await callbackErr;
+		// Mirror runLoopbackFlow: close immediately after the rejection.
+		await server.close();
+		const res = await fetchPromise;
+		expect(res.status).toBe(400);
+		const html = await res.text();
+		expect(html).toContain("API access not available on this plan");
 	});
 
 	test("awaitCallback times out", async () => {

--- a/tests/auth/oauth-loopback.test.ts
+++ b/tests/auth/oauth-loopback.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+	buildAuthorizeUrl,
+	exchangeCodeForToken,
+	generatePkce,
+	generateState,
+	type LoopbackServer,
+	runLoopbackFlow,
+	startLoopbackServer,
+} from "../../src/auth/oauth-loopback.ts";
+import { CliError } from "../../src/errors/cli-error.ts";
+
+const BASE = "https://oauth.test.geekbot.com";
+const CLIENT_ID = "geekbot-cli";
+
+function jsonResponse(status: number, body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+function base64urlSha256(input: string): string {
+	return createHash("sha256")
+		.update(input)
+		.digest("base64")
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/, "");
+}
+
+// ── PKCE / state ─────────────────────────────────────────────────────
+
+describe("generatePkce", () => {
+	test("verifier is base64url-safe, 43+ chars", () => {
+		const pkce = generatePkce();
+		expect(pkce.method).toBe("S256");
+		expect(pkce.verifier.length).toBeGreaterThanOrEqual(43);
+		expect(pkce.verifier).toMatch(/^[A-Za-z0-9\-_]+$/);
+	});
+
+	test("challenge is the base64url(sha256(verifier))", () => {
+		const pkce = generatePkce();
+		expect(pkce.challenge).toBe(base64urlSha256(pkce.verifier));
+	});
+
+	test("each call returns a different verifier", () => {
+		const a = generatePkce();
+		const b = generatePkce();
+		expect(a.verifier).not.toBe(b.verifier);
+	});
+});
+
+describe("generateState", () => {
+	test("returns a base64url string", () => {
+		const s = generateState();
+		expect(s.length).toBeGreaterThanOrEqual(20);
+		expect(s).toMatch(/^[A-Za-z0-9\-_]+$/);
+	});
+
+	test("each call is unique", () => {
+		expect(generateState()).not.toBe(generateState());
+	});
+});
+
+// ── buildAuthorizeUrl ────────────────────────────────────────────────
+
+describe("buildAuthorizeUrl", () => {
+	test("encodes every required parameter into /v2/authorize", () => {
+		const url = buildAuthorizeUrl({
+			baseUrl: BASE,
+			clientId: CLIENT_ID,
+			redirectUri: "http://127.0.0.1:12345/callback",
+			state: "state-xyz",
+			codeChallenge: "challenge-abc",
+			scope: "cli",
+			deviceName: "laptop",
+			ttlDays: 30,
+		});
+		const parsed = new URL(url);
+		expect(parsed.origin + parsed.pathname).toBe(`${BASE}/v2/authorize`);
+		expect(parsed.searchParams.get("response_type")).toBe("code");
+		expect(parsed.searchParams.get("client_id")).toBe(CLIENT_ID);
+		expect(parsed.searchParams.get("redirect_uri")).toBe("http://127.0.0.1:12345/callback");
+		expect(parsed.searchParams.get("state")).toBe("state-xyz");
+		expect(parsed.searchParams.get("code_challenge")).toBe("challenge-abc");
+		expect(parsed.searchParams.get("code_challenge_method")).toBe("S256");
+		expect(parsed.searchParams.get("scope")).toBe("cli");
+		expect(parsed.searchParams.get("device_name")).toBe("laptop");
+		expect(parsed.searchParams.get("ttl_days")).toBe("30");
+	});
+});
+
+// ── exchangeCodeForToken ─────────────────────────────────────────────
+
+describe("exchangeCodeForToken", () => {
+	test("POSTs form-encoded grant=authorization_code with PKCE verifier", async () => {
+		let captured: { url: string; init: RequestInit } | null = null;
+		const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+			captured = {
+				url: typeof input === "string" ? input : (input as Request).url,
+				init: init ?? {},
+			};
+			return jsonResponse(200, {
+				access_token: "cli_xyz",
+				token_type: "Bearer",
+				expires_in: 2592000,
+				scope: "cli",
+			});
+		}) as unknown as typeof globalThis.fetch;
+
+		const token = await exchangeCodeForToken({
+			code: "auth-code-abc",
+			codeVerifier: "verifier-abc",
+			redirectUri: "http://127.0.0.1:5555/callback",
+			baseUrl: BASE,
+			clientId: CLIENT_ID,
+			fetchImpl,
+		});
+
+		expect(token.access_token).toBe("cli_xyz");
+		expect(token.scope).toBe("cli");
+		expect(token.token_type).toBe("Bearer");
+
+		if (!captured) throw new Error("fetchImpl was not called");
+		expect(captured.url).toBe(`${BASE}/v2/token`);
+		expect(captured.init.method).toBe("POST");
+		const body = new URLSearchParams(captured.init.body as string);
+		expect(body.get("grant_type")).toBe("authorization_code");
+		expect(body.get("code")).toBe("auth-code-abc");
+		expect(body.get("code_verifier")).toBe("verifier-abc");
+		expect(body.get("client_id")).toBe(CLIENT_ID);
+		expect(body.get("redirect_uri")).toBe("http://127.0.0.1:5555/callback");
+	});
+
+	test("maps an invalid_grant error to a CliError with oauth_invalid_grant code", async () => {
+		const fetchImpl = (async () =>
+			jsonResponse(400, {
+				error: "invalid_grant",
+				error_description: "authorization code is invalid or expired",
+			})) as unknown as typeof globalThis.fetch;
+
+		try {
+			await exchangeCodeForToken({
+				code: "x",
+				codeVerifier: "y",
+				redirectUri: "http://127.0.0.1:1/callback",
+				baseUrl: BASE,
+				clientId: CLIENT_ID,
+				fetchImpl,
+			});
+			throw new Error("should have thrown");
+		} catch (e) {
+			expect(e).toBeInstanceOf(CliError);
+			const err = e as CliError;
+			expect(err.code).toBe("oauth_invalid_grant");
+			expect(err.message).toContain("invalid or expired");
+		}
+	});
+
+	test("rejects token responses missing access_token", async () => {
+		const fetchImpl = (async () =>
+			jsonResponse(200, { token_type: "Bearer" })) as unknown as typeof globalThis.fetch;
+		try {
+			await exchangeCodeForToken({
+				code: "x",
+				codeVerifier: "y",
+				redirectUri: "http://127.0.0.1:1/callback",
+				baseUrl: BASE,
+				clientId: CLIENT_ID,
+				fetchImpl,
+			});
+			throw new Error("should have thrown");
+		} catch (e) {
+			expect(e).toBeInstanceOf(CliError);
+			expect((e as CliError).code).toBe("oauth_invalid_response");
+		}
+	});
+
+	test("network failures surface as retryable network_error", async () => {
+		const fetchImpl = (async () => {
+			throw new Error("ECONNREFUSED");
+		}) as unknown as typeof globalThis.fetch;
+		try {
+			await exchangeCodeForToken({
+				code: "x",
+				codeVerifier: "y",
+				redirectUri: "http://127.0.0.1:1/callback",
+				baseUrl: BASE,
+				clientId: CLIENT_ID,
+				fetchImpl,
+			});
+			throw new Error("should have thrown");
+		} catch (e) {
+			expect(e).toBeInstanceOf(CliError);
+			expect((e as CliError).code).toBe("network_error");
+			expect((e as CliError).retryable).toBe(true);
+		}
+	});
+});
+
+// ── Loopback server ──────────────────────────────────────────────────
+
+describe("startLoopbackServer", () => {
+	test("binds 127.0.0.1, exposes a redirect URI with the actual port, and resolves on /callback", async () => {
+		const server = await startLoopbackServer();
+		try {
+			expect(server.port).toBeGreaterThan(0);
+			expect(server.redirectUri).toBe(`http://127.0.0.1:${server.port}/callback`);
+
+			const callback = server.awaitCallback("state-xyz", 5000);
+			const response = await fetch(`${server.redirectUri}?code=abc&state=state-xyz`);
+			expect(response.status).toBe(200);
+			expect(await response.text()).toContain("Signed in to Geekbot CLI");
+
+			const result = await callback;
+			expect(result.code).toBe("abc");
+			expect(result.state).toBe("state-xyz");
+		} finally {
+			await server.close();
+		}
+	});
+
+	test("state mismatch throws oauth_state_mismatch", async () => {
+		const server = await startLoopbackServer();
+		try {
+			const callback = server.awaitCallback("expected-state", 5000).catch((e) => e);
+			await fetch(`${server.redirectUri}?code=abc&state=evil-state`);
+			const e = await callback;
+			expect(e).toBeInstanceOf(CliError);
+			expect((e as CliError).code).toBe("oauth_state_mismatch");
+		} finally {
+			await server.close();
+		}
+	});
+
+	test("error callback rejects with oauth_<error>", async () => {
+		const server = await startLoopbackServer();
+		try {
+			const callback = server.awaitCallback("s", 5000).catch((e) => e);
+			const res = await fetch(
+				`${server.redirectUri}?error=access_denied&error_description=user%20said%20no&state=s`,
+			);
+			expect(res.status).toBe(400);
+			const e = await callback;
+			expect(e).toBeInstanceOf(CliError);
+			expect((e as CliError).code).toBe("oauth_access_denied");
+			expect((e as CliError).message).toContain("user said no");
+		} finally {
+			await server.close();
+		}
+	});
+
+	test("non-/callback paths return 404", async () => {
+		const server = await startLoopbackServer();
+		try {
+			const res = await fetch(`http://127.0.0.1:${server.port}/something-else`);
+			expect(res.status).toBe(404);
+		} finally {
+			await server.close();
+		}
+	});
+
+	test("missing code returns 400 and rejects with oauth_invalid_callback", async () => {
+		const server = await startLoopbackServer();
+		try {
+			const callback = server.awaitCallback("s", 5000).catch((e) => e);
+			const res = await fetch(`${server.redirectUri}?state=s`);
+			expect(res.status).toBe(400);
+			const e = await callback;
+			expect(e).toBeInstanceOf(CliError);
+			expect((e as CliError).code).toBe("oauth_invalid_callback");
+		} finally {
+			await server.close();
+		}
+	});
+
+	test("awaitCallback times out", async () => {
+		const server = await startLoopbackServer();
+		try {
+			const start = Date.now();
+			const e = await server.awaitCallback("s", 50).catch((err) => err);
+			expect(e).toBeInstanceOf(CliError);
+			expect((e as CliError).code).toBe("oauth_callback_timeout");
+			expect(Date.now() - start).toBeGreaterThanOrEqual(40);
+		} finally {
+			await server.close();
+		}
+	});
+});
+
+// ── runLoopbackFlow ──────────────────────────────────────────────────
+
+describe("runLoopbackFlow", () => {
+	function fakeServer(callback: { code: string; state?: string }): LoopbackServer {
+		let actualState = "";
+		return {
+			port: 0,
+			redirectUri: "http://127.0.0.1:9999/callback",
+			awaitCallback: async (expectedState: string) => {
+				actualState = callback.state ?? expectedState;
+				return { code: callback.code, state: actualState };
+			},
+			close: async () => {},
+		};
+	}
+
+	test("end-to-end: opens browser, awaits callback, exchanges code", async () => {
+		let openedUrl: string | null = null;
+		let exchangedBody: string | null = null;
+		const fetchImpl = (async (_input: unknown, init?: RequestInit) => {
+			exchangedBody = (init?.body as string) ?? null;
+			return jsonResponse(200, {
+				access_token: "cli_zzz",
+				token_type: "Bearer",
+				expires_in: 2592000,
+				scope: "cli",
+			});
+		}) as unknown as typeof globalThis.fetch;
+
+		const token = await runLoopbackFlow(
+			{ deviceName: "test-device", ttlDays: 30 },
+			{
+				baseUrl: BASE,
+				clientId: CLIENT_ID,
+				fetchImpl,
+				openBrowser: (url) => {
+					openedUrl = url;
+				},
+				startServer: async () => fakeServer({ code: "the-auth-code" }),
+				prompt: () => {},
+			},
+		);
+
+		expect(token.access_token).toBe("cli_zzz");
+		expect(openedUrl).toContain(`${BASE}/v2/authorize?`);
+		expect(openedUrl).toContain("device_name=test-device");
+		expect(openedUrl).toContain("ttl_days=30");
+		expect(openedUrl).toContain("code_challenge=");
+		expect(openedUrl).toContain("code_challenge_method=S256");
+		expect(openedUrl).toContain("redirect_uri=http%3A%2F%2F127.0.0.1%3A9999%2Fcallback");
+
+		if (!exchangedBody) throw new Error("token exchange request body was never captured");
+		const body = new URLSearchParams(exchangedBody);
+		expect(body.get("code")).toBe("the-auth-code");
+		expect(body.get("grant_type")).toBe("authorization_code");
+		expect(body.get("code_verifier")?.length ?? 0).toBeGreaterThan(40);
+	});
+
+	test("--no-browser skips opener but still runs", async () => {
+		const opener = (() => {
+			throw new Error("should not be called");
+		}) as (url: string) => void;
+		const fetchImpl = (async () =>
+			jsonResponse(200, { access_token: "cli_x" })) as unknown as typeof globalThis.fetch;
+
+		const token = await runLoopbackFlow(
+			{ noBrowser: true, ttlDays: 30 },
+			{
+				baseUrl: BASE,
+				clientId: CLIENT_ID,
+				fetchImpl,
+				openBrowser: opener,
+				startServer: async () => fakeServer({ code: "abc" }),
+				prompt: () => {},
+			},
+		);
+		expect(token.access_token).toBe("cli_x");
+	});
+
+	test("rejects ttlDays not in the allowed list", async () => {
+		try {
+			await runLoopbackFlow(
+				// @ts-expect-error -- intentionally invalid
+				{ ttlDays: 14 },
+				{
+					baseUrl: BASE,
+					clientId: CLIENT_ID,
+					startServer: async () => fakeServer({ code: "abc" }),
+					fetchImpl: (async () => jsonResponse(200, {})) as unknown as typeof globalThis.fetch,
+					prompt: () => {},
+				},
+			);
+			throw new Error("should have thrown");
+		} catch (e) {
+			expect(e).toBeInstanceOf(CliError);
+			expect((e as CliError).code).toBe("validation_error");
+		}
+	});
+
+	test("closes the loopback server even on token-exchange failure", async () => {
+		let closed = false;
+		const server: LoopbackServer = {
+			port: 0,
+			redirectUri: "http://127.0.0.1:1/callback",
+			awaitCallback: async () => ({ code: "abc", state: "s" }),
+			close: async () => {
+				closed = true;
+			},
+		};
+		const fetchImpl = (async () =>
+			jsonResponse(400, { error: "invalid_grant" })) as unknown as typeof globalThis.fetch;
+
+		try {
+			await runLoopbackFlow(
+				{ ttlDays: 30 },
+				{
+					baseUrl: BASE,
+					clientId: CLIENT_ID,
+					fetchImpl,
+					openBrowser: () => {},
+					startServer: async () => server,
+					prompt: () => {},
+				},
+			);
+			throw new Error("should have thrown");
+		} catch (e) {
+			expect(e).toBeInstanceOf(CliError);
+			expect((e as CliError).code).toBe("oauth_invalid_grant");
+		}
+		expect(closed).toBe(true);
+	});
+});

--- a/tests/cli/commands/auth.test.ts
+++ b/tests/cli/commands/auth.test.ts
@@ -30,9 +30,14 @@ describe("createAuthCommand", () => {
 		expect(cmd.name()).toBe("auth");
 	});
 
-	test("registers 3 subcommands", () => {
+	test("registers 4 subcommands", () => {
 		const cmd = createAuthCommand();
-		expect(cmd.commands.length).toBe(3);
+		expect(cmd.commands.length).toBe(4);
+	});
+
+	test("registers 'login' subcommand", () => {
+		const cmd = createAuthCommand();
+		expect(cmd.commands.find((c) => c.name() === "login")).toBeDefined();
 	});
 
 	test("registers 'setup' subcommand", () => {

--- a/tests/handlers/auth-handlers.test.ts
+++ b/tests/handlers/auth-handlers.test.ts
@@ -67,7 +67,7 @@ mock.module("../../src/output/formatter.ts", () => ({
 }));
 
 // Import handlers AFTER mocks
-const { handleAuthSetup, handleAuthStatus, handleAuthRemove } = await import(
+const { handleAuthSetup, handleAuthStatus, handleAuthRemove, handleAuthLogin } = await import(
 	"../../src/handlers/auth-handlers.ts"
 );
 const { CliError } = await import("../../src/errors/cli-error.ts");
@@ -318,6 +318,231 @@ describe("handleAuthStatus", () => {
 		} catch (e) {
 			expect((e as Error).message).toBe("network failure");
 		}
+	});
+});
+
+// ── handleAuthLogin ──────────────────────────────────────────────────
+
+describe("handleAuthLogin", () => {
+	const BASE = "https://oauth.test";
+
+	function jsonResponse(status: number, body: unknown): Response {
+		return new Response(JSON.stringify(body), {
+			status,
+			headers: { "content-type": "application/json" },
+		});
+	}
+
+	/** Builds a fake loopback server that resolves with a fixed code/state. */
+	function fakeServer(opts: { code?: string; state?: string; throwAt?: "callback" } = {}) {
+		let closed = false;
+		return {
+			port: 0,
+			redirectUri: "http://127.0.0.1:9999/callback",
+			awaitCallback: async (expectedState: string) => {
+				if (opts.throwAt === "callback") {
+					throw new CliError("access_denied", "oauth_access_denied", 4, false);
+				}
+				return { code: opts.code ?? "auth-code", state: opts.state ?? expectedState };
+			},
+			close: async () => {
+				closed = true;
+			},
+			get closed(): boolean {
+				return closed;
+			},
+		};
+	}
+
+	test("runs loopback flow, stores token, verifies via /v1/me, writes success envelope", async () => {
+		const openBrowser = mock((_url: string) => {});
+		const promptWrites: string[] = [];
+		const prompt = (text: string) => {
+			promptWrites.push(text);
+		};
+
+		const fetchImpl = mock(async () =>
+			jsonResponse(200, {
+				access_token: "cli_minted_xyz",
+				token_type: "Bearer",
+				expires_in: 2592000,
+				scope: "cli",
+			}),
+		) as unknown as typeof globalThis.fetch;
+
+		const server = fakeServer({ code: "the-auth-code" });
+
+		await handleAuthLogin(
+			{
+				deviceName: "test-device",
+				ttlDays: 30,
+				loopback: {
+					baseUrl: BASE,
+					clientId: "geekbot-cli",
+					fetchImpl,
+					openBrowser,
+					startServer: async () => server,
+					prompt,
+				},
+			},
+			GLOBAL_OPTS,
+		);
+
+		expect(mockGet).toHaveBeenCalledWith("/v1/me");
+		expect(mockSetKeychainKey).toHaveBeenCalledWith("cli_minted_xyz");
+		expect(openBrowser).toHaveBeenCalledTimes(1);
+		expect(openBrowser.mock.calls[0][0]).toContain(`${BASE}/v2/authorize`);
+		expect(openBrowser.mock.calls[0][0]).toContain("device_name=test-device");
+		expect(openBrowser.mock.calls[0][0]).toContain("ttl_days=30");
+
+		const promptText = promptWrites.join("");
+		expect(promptText).toContain("Listening on http://127.0.0.1:9999/callback");
+		expect(promptText).toContain("state is single-use");
+
+		const envelope = mockWriteOutput.mock.calls[0][0] as {
+			ok: boolean;
+			data: {
+				authenticated: boolean;
+				method: string;
+				username: string;
+				email: string;
+				token_type: string;
+				scope: string;
+			};
+		};
+		expect(envelope.ok).toBe(true);
+		expect(envelope.data.authenticated).toBe(true);
+		expect(envelope.data.method).toBe("oauth_loopback");
+		expect(envelope.data.username).toBe("testuser");
+		expect(envelope.data.email).toBe("test@example.com");
+		expect(envelope.data.token_type).toBe("Bearer");
+		expect(envelope.data.scope).toBe("cli");
+
+		expect(server.closed).toBe(true);
+	});
+
+	test("--no-browser skips opener but still completes", async () => {
+		const openBrowser = mock(() => {});
+		const fetchImpl = mock(async () =>
+			jsonResponse(200, { access_token: "cli_2" }),
+		) as unknown as typeof globalThis.fetch;
+
+		await handleAuthLogin(
+			{
+				noBrowser: true,
+				ttlDays: 30,
+				loopback: {
+					baseUrl: BASE,
+					clientId: "geekbot-cli",
+					fetchImpl,
+					openBrowser,
+					startServer: async () => fakeServer(),
+					prompt: () => {},
+				},
+			},
+			GLOBAL_OPTS,
+		);
+
+		expect(openBrowser).not.toHaveBeenCalled();
+		expect(mockSetKeychainKey).toHaveBeenCalledWith("cli_2");
+	});
+
+	test("does not store token if /v1/me verification fails", async () => {
+		mockGet.mockImplementation(() =>
+			Promise.reject(new CliError("Unauthorized", "unauthorized", 4, false)),
+		);
+		const fetchImpl = mock(async () =>
+			jsonResponse(200, { access_token: "cli_bad" }),
+		) as unknown as typeof globalThis.fetch;
+
+		try {
+			await handleAuthLogin(
+				{
+					noBrowser: true,
+					ttlDays: 30,
+					loopback: {
+						baseUrl: BASE,
+						clientId: "geekbot-cli",
+						fetchImpl,
+						openBrowser: () => {},
+						startServer: async () => fakeServer(),
+						prompt: () => {},
+					},
+				},
+				GLOBAL_OPTS,
+			);
+			throw new Error("should have thrown");
+		} catch (e) {
+			expect(e).toBeInstanceOf(CliError);
+			expect((e as InstanceType<typeof CliError>).code).toBe("unauthorized");
+		}
+
+		expect(mockSetKeychainKey).not.toHaveBeenCalled();
+	});
+
+	test("warns when replacing an existing keychain entry", async () => {
+		mockGetKeychainKey.mockReturnValue("old-key");
+		const stderrSpy = mock(() => true);
+		const origWrite = process.stderr.write;
+		process.stderr.write = stderrSpy as unknown as typeof process.stderr.write;
+
+		try {
+			const fetchImpl = mock(async () =>
+				jsonResponse(200, { access_token: "cli_new" }),
+			) as unknown as typeof globalThis.fetch;
+
+			await handleAuthLogin(
+				{
+					noBrowser: true,
+					ttlDays: 30,
+					loopback: {
+						baseUrl: BASE,
+						clientId: "geekbot-cli",
+						fetchImpl,
+						openBrowser: () => {},
+						startServer: async () => fakeServer(),
+						prompt: () => {},
+					},
+				},
+				GLOBAL_OPTS,
+			);
+
+			const text = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+			expect(text).toContain("Replacing existing API key in keychain");
+		} finally {
+			process.stderr.write = origWrite;
+		}
+	});
+
+	test("propagates access_denied from the callback step without calling /v1/me", async () => {
+		const fetchImpl = mock(async () =>
+			jsonResponse(500, { error: "should_not_be_called" }),
+		) as unknown as typeof globalThis.fetch;
+
+		try {
+			await handleAuthLogin(
+				{
+					noBrowser: true,
+					ttlDays: 30,
+					loopback: {
+						baseUrl: BASE,
+						clientId: "geekbot-cli",
+						fetchImpl,
+						openBrowser: () => {},
+						startServer: async () => fakeServer({ throwAt: "callback" }),
+						prompt: () => {},
+					},
+				},
+				GLOBAL_OPTS,
+			);
+			throw new Error("should have thrown");
+		} catch (e) {
+			expect(e).toBeInstanceOf(CliError);
+			expect((e as InstanceType<typeof CliError>).code).toBe("oauth_access_denied");
+		}
+
+		expect(mockSetKeychainKey).not.toHaveBeenCalled();
+		expect(mockGet).not.toHaveBeenCalled();
 	});
 });
 

--- a/tests/utils/constants.test.ts
+++ b/tests/utils/constants.test.ts
@@ -5,7 +5,11 @@ import {
 	API_BASE_URL,
 	APP_NAME,
 	APP_VERSION,
+	OAUTH_BASE_URL,
+	OAUTH_CLI_ALLOWED_TTL_DAYS,
+	OAUTH_CLIENT_ID,
 	resolveApiBaseUrl,
+	resolveOAuthBaseUrl,
 } from "../../src/utils/constants.ts";
 
 describe("constants", () => {
@@ -23,6 +27,18 @@ describe("constants", () => {
 
 	test("API_BASE_URL defaults to https://api.geekbot.com", () => {
 		expect(API_BASE_URL).toBe("https://api.geekbot.com");
+	});
+
+	test("OAUTH_BASE_URL defaults to https://oauth.geekbot.com", () => {
+		expect(OAUTH_BASE_URL).toBe("https://oauth.geekbot.com");
+	});
+
+	test("OAUTH_CLIENT_ID equals 'geekbot-cli'", () => {
+		expect(OAUTH_CLIENT_ID).toBe("geekbot-cli");
+	});
+
+	test("OAUTH_CLI_ALLOWED_TTL_DAYS exposes the auth server's whitelist", () => {
+		expect([...OAUTH_CLI_ALLOWED_TTL_DAYS]).toEqual([7, 30, 90, 180, 365]);
 	});
 });
 
@@ -57,5 +73,33 @@ describe("resolveApiBaseUrl", () => {
 
 	test("rejects uppercase HTTPS scheme (case-sensitive check)", () => {
 		expect(() => resolveApiBaseUrl("HTTPS://api.geekbot.com")).toThrow(CliError);
+	});
+});
+
+describe("resolveOAuthBaseUrl", () => {
+	test("returns default when no override provided", () => {
+		expect(resolveOAuthBaseUrl(undefined)).toBe("https://oauth.geekbot.com");
+	});
+
+	test("accepts valid HTTPS override", () => {
+		expect(resolveOAuthBaseUrl("https://staging-oauth.geekbot.com")).toBe(
+			"https://staging-oauth.geekbot.com",
+		);
+	});
+
+	test("rejects HTTP override (plaintext exfiltrates token)", () => {
+		expect(() => resolveOAuthBaseUrl("http://evil.com")).toThrow(CliError);
+	});
+
+	test("rejects non-URL override", () => {
+		expect(() => resolveOAuthBaseUrl("not-a-url")).toThrow(CliError);
+	});
+
+	test("rejects empty string", () => {
+		expect(() => resolveOAuthBaseUrl("")).toThrow(CliError);
+	});
+
+	test("error message mentions HTTPS requirement", () => {
+		expect(() => resolveOAuthBaseUrl("http://evil.com")).toThrow(/HTTPS/i);
 	});
 });


### PR DESCRIPTION
- New `geekbot auth login` subcommand runs the OAuth 2.0 authorization-code flow with PKCE and a 127.0.0.1 loopback redirect, then writes the resulting cli_* token to the OS keychain. Same storage as `auth setup`, no API key paste.
- Flags: --no-browser, --device-name, --ttl-days (7/30/90/180/365).
- OAuth base URL is configurable via GEEKBOT_OAUTH_BASE_URL (must be https://); defaults to https://oauth.geekbot.com.
- Setup/run skills updated to drive `auth login` as the primary flow; API key remains a documented fallback.
- README documents the new flow under Authentication and the auth subcommand table; manual install and plugin-install sections now point at OAuth first.