### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "geekbot-cli",
-	"version": "0.2.4",
+	"version": "1.0.0",
 	"description": "CLI tool for managing Geekbot standups, reports, and polls — designed for AI agents and humans",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
Bumps `package.json` to `1.0.0` ahead of the first stable release.

Version-only change. Once merged, tag `v1.0.0` on `main` and publish the GitHub release — the publish workflow will push `geekbot-cli@1.0.0` to npm.