### PR TITLE
feat: add participation commands for standups and polls

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ The CLI follows a `geekbot <resource> <action> [options]` pattern. Run `geekbot 
 
 | Resource | Actions | What it does |
 |----------|---------|--------------|
-| `standup` | `list` · `get <id>` · `create` · `start <id>` | List, inspect, create, or immediately trigger standups |
+| `standup` | `list` · `get <id>` · `participation <id>` · `create` · `start <id>` | List, inspect, create, trigger standups, or read participation |
 | `report` | `list` · `get <id>` · `create` · `edit <id>` · `delete <id>` | Read and submit standup reports |
-| `poll` | `list` · `get <id>` · `create` · `votes <id>` | Manage polls and read results *(Slack teams only)* |
+| `poll` | `list` · `get <id>` · `votes <id>` · `participation <id>` · `create` | Manage polls, read results and response rate *(Slack teams only)* |
 | `me` | `show` · `teams` | Show your profile or the teams you belong to |
 | `team` | `list` | List teams with their members |
 | `auth` | `login` · `setup` · `status` · `remove` | Manage authentication (see below) |
@@ -119,9 +119,11 @@ A few common examples:
 geekbot standup list
 geekbot standup create --name "Sprint Retro" --channel "#engineering" \
   --questions '["What went well?","What could improve?"]'
+geekbot standup participation 123 --since 2026-01-01 --until 2026-02-01
 geekbot report create --standup-id 123 --answers '{"101":"Shipped auth","102":"Writing tests"}'
 geekbot poll create --name "Lunch" --channel "#general" \
   --question "Where to?" --choices '["Pizza","Sushi","Tacos"]'
+geekbot poll participation 456
 ```
 
 ## 🔑 Authentication

--- a/skills/geekbot-run/cli-commands.md
+++ b/skills/geekbot-run/cli-commands.md
@@ -68,6 +68,31 @@ populated by `--include`).
 
 This is the primary way to discover question IDs for report submission.
 
+### standup participation
+
+Per-occurrence participation for a standup via `GET /v2/standups/<id>/participation`.
+Cursor-paginated, newest-first; each invocation returns one page.
+
+```bash
+geekbot standup participation 123
+geekbot standup participation 123 --since 2026-01-01 --until 2026-02-01
+geekbot standup participation 123 --page-size 50
+geekbot standup participation 123 --cursor "<token>"        # next page
+```
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--since <date>` | — | ISO 8601 or `YYYY-MM-DD` (inclusive lower bound) |
+| `--until <date>` | — | ISO 8601 or `YYYY-MM-DD` (exclusive upper bound) |
+| `--cursor <token>` | — | Opaque pagination cursor from a previous response |
+| `--page-size <n>` | `30` | Page size (1-100) |
+
+Returns: `data` is an array of per-occurrence entries, newest-first, with
+`metadata.next_cursor` / `metadata.has_more` for pagination. Each entry has
+`standup_id`, `date`, `expected` (members expected to respond — out-of-office /
+vacation members who did not report are excluded), `responded`,
+`participation_rate` (0-1), and `excluded.vacation`.
+
 ### standup create (v2)
 
 Create a new standup via `POST /v2/standups`. Only `--channel` and `--questions`
@@ -277,6 +302,29 @@ View voting results for a poll.
 geekbot poll votes 456
 geekbot poll votes 456 --after "2026-03-01" --before "2026-03-15"
 ```
+
+### poll participation
+
+Per-broadcast response rate for a poll via `GET /v2/polls/<id>/participation`.
+Cursor-paginated, newest-first. Slack teams only.
+
+```bash
+geekbot poll participation 456
+geekbot poll participation 456 --since 2026-01-01 --until 2026-02-01
+geekbot poll participation 456 --page-size 50
+```
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--since <date>` | — | ISO 8601 or `YYYY-MM-DD` (inclusive lower bound) |
+| `--until <date>` | — | ISO 8601 or `YYYY-MM-DD` (exclusive upper bound) |
+| `--cursor <token>` | — | Opaque pagination cursor from a previous response |
+| `--page-size <n>` | `30` | Page size (1-100) |
+
+Returns: `data` is an array of per-broadcast entries, newest-first. Each has
+`poll_id`, `date`, `expected` (recipients), `responded` (distinct voters), and
+`participation_rate` (0-1). A rate above 1.0 means more people voted than the
+poll's current members — a sign it needs syncing.
 
 ---
 

--- a/src/cli/commands/poll.ts
+++ b/src/cli/commands/poll.ts
@@ -4,6 +4,7 @@ import {
 	handlePollCreate,
 	handlePollGet,
 	handlePollList,
+	handlePollParticipation,
 	handlePollVotes,
 } from "../../handlers/poll-handlers.ts";
 import { getGlobalOptions } from "../globals.ts";
@@ -119,6 +120,37 @@ export function createPollCommand(): Command {
 			try {
 				const opts = this.opts();
 				await handlePollVotes(id, { after: opts.after, before: opts.before }, globalOpts);
+			} catch (error) {
+				handleError(error);
+			}
+		});
+
+	poll
+		.command("participation")
+		.description("Per-broadcast participation (response rate) for a poll (v2)")
+		.argument("<id>", "Poll ID (numeric)")
+		.option("--since <date>", "ISO 8601 or YYYY-MM-DD (inclusive lower bound)")
+		.option("--until <date>", "ISO 8601 or YYYY-MM-DD (exclusive upper bound)")
+		.option("--cursor <token>", "Opaque pagination cursor from a previous response")
+		.option("--page-size <n>", "Page size (1-100, default 30)")
+		.addHelpText(
+			"after",
+			"\nExamples:\n  geekbot poll participation 456\n  geekbot poll participation 456 --since 2026-01-01 --until 2026-02-01\n  geekbot poll participation 456 --page-size 50",
+		)
+		.action(async function (this: Command, id: string) {
+			const globalOpts = getGlobalOptions(this);
+			try {
+				const opts = this.opts();
+				await handlePollParticipation(
+					id,
+					{
+						since: opts.since,
+						until: opts.until,
+						cursor: opts.cursor,
+						pageSize: opts.pageSize,
+					},
+					globalOpts,
+				);
 			} catch (error) {
 				handleError(error);
 			}

--- a/src/cli/commands/standup.ts
+++ b/src/cli/commands/standup.ts
@@ -4,6 +4,7 @@ import {
 	handleStandupCreate,
 	handleStandupGet,
 	handleStandupList,
+	handleStandupParticipation,
 	handleStandupStart,
 } from "../../handlers/standup-handlers.ts";
 import { getGlobalOptions } from "../globals.ts";
@@ -43,6 +44,37 @@ export function createStandupCommand(): Command {
 						cursor: opts.cursor,
 						pageSize: opts.pageSize,
 						include: opts.include,
+					},
+					globalOpts,
+				);
+			} catch (error) {
+				handleError(error);
+			}
+		});
+
+	standup
+		.command("participation")
+		.description("Per-occurrence participation for a standup (v2)")
+		.argument("<id>", "Standup ID (numeric)")
+		.option("--since <date>", "ISO 8601 or YYYY-MM-DD (inclusive lower bound)")
+		.option("--until <date>", "ISO 8601 or YYYY-MM-DD (exclusive upper bound)")
+		.option("--cursor <token>", "Opaque pagination cursor from a previous response")
+		.option("--page-size <n>", "Page size (1-100, default 30)")
+		.addHelpText(
+			"after",
+			"\nExamples:\n  geekbot standup participation 123\n  geekbot standup participation 123 --since 2026-01-01 --until 2026-02-01\n  geekbot standup participation 123 --page-size 50",
+		)
+		.action(async function (this: Command, id: string) {
+			const globalOpts = getGlobalOptions(this);
+			try {
+				const opts = this.opts();
+				await handleStandupParticipation(
+					id,
+					{
+						since: opts.since,
+						until: opts.until,
+						cursor: opts.cursor,
+						pageSize: opts.pageSize,
 					},
 					globalOpts,
 				);

--- a/src/handlers/poll-handlers.ts
+++ b/src/handlers/poll-handlers.ts
@@ -10,6 +10,7 @@ import { writeOutput } from "../output/formatter.ts";
 import {
 	V2PollItemResponseSchema,
 	V2PollListResponseSchema,
+	V2PollParticipationResponseSchema,
 	V2PollVotesResponseSchema,
 } from "../schemas/v2-poll.ts";
 import { parseChoicesInput, parseV2DateFilter } from "../utils/input-parsers.ts";
@@ -44,6 +45,13 @@ export interface PollCreateOptions {
 export interface PollVotesOptions {
 	after?: string;
 	before?: string;
+}
+
+export interface PollParticipationOptions {
+	since?: string;
+	until?: string;
+	cursor?: string;
+	pageSize?: string;
 }
 
 // ── Platform Error Helper ─────────────────────────────────────────────
@@ -249,6 +257,40 @@ export async function handlePollVotes(
 			const parsed = V2PollVotesResponseSchema.parse(raw);
 
 			writeOutput(success(parsed.data));
+		}, globalOpts);
+	});
+}
+
+/**
+ * Handle `geekbot poll participation` command.
+ * Fetches per-broadcast participation from GET /v2/polls/<id>/participation
+ * (cursor-paginated, single page per call).
+ */
+export async function handlePollParticipation(
+	id: string,
+	options: PollParticipationOptions,
+	globalOpts: GlobalOptions,
+): Promise<void> {
+	const numericId = validateNumericId(id, "poll ID");
+
+	await wrapPlatformError(async () => {
+		await enrichPollNotFound(async (client) => {
+			const params = buildParams({
+				since: options.since ? parseV2DateFilter(options.since, "--since") : undefined,
+				until: options.until ? parseV2DateFilter(options.until, "--until") : undefined,
+				cursor: options.cursor,
+				limit: options.pageSize ? String(validateLimit(options.pageSize)) : undefined,
+			});
+
+			const raw = await client.get<unknown>(`/v2/polls/${numericId}/participation`, params);
+			const parsed = V2PollParticipationResponseSchema.parse(raw);
+
+			writeOutput(
+				successList(parsed.data, {
+					next_cursor: parsed.next_cursor,
+					has_more: parsed.has_more,
+				}),
+			);
 		}, globalOpts);
 	});
 }

--- a/src/handlers/standup-handlers.ts
+++ b/src/handlers/standup-handlers.ts
@@ -6,7 +6,11 @@ import type { HttpClient } from "../http/client.ts";
 import { idempotencyHeader } from "../http/idempotency.ts";
 import { success, successList } from "../output/envelope.ts";
 import { writeOutput } from "../output/formatter.ts";
-import { V2StandupItemResponseSchema, V2StandupListResponseSchema } from "../schemas/v2-standup.ts";
+import {
+	V2StandupItemResponseSchema,
+	V2StandupListResponseSchema,
+	V2StandupParticipationResponseSchema,
+} from "../schemas/v2-standup.ts";
 import { parseQuestionsInputV2, parseV2DateFilter } from "../utils/input-parsers.ts";
 import { buildReceipt } from "../utils/receipt.ts";
 import {
@@ -120,6 +124,44 @@ export async function handleStandupList(
 
 	const raw = await client.get<unknown>("/v2/standups", params);
 	const parsed = V2StandupListResponseSchema.parse(raw);
+
+	writeOutput(
+		successList(parsed.data, {
+			next_cursor: parsed.next_cursor,
+			has_more: parsed.has_more,
+		}),
+	);
+}
+
+export interface StandupParticipationOptions {
+	since?: string;
+	until?: string;
+	cursor?: string;
+	pageSize?: string;
+}
+
+/**
+ * Handle `geekbot standup participation` command.
+ * Fetches per-occurrence participation from GET /v2/standups/<id>/participation
+ * (cursor-paginated, single page per call).
+ */
+export async function handleStandupParticipation(
+	id: string,
+	options: StandupParticipationOptions,
+	globalOpts: GlobalOptions,
+): Promise<void> {
+	const numericId = validateNumericId(id, "standup ID");
+	const client = await createAuthenticatedClient(globalOpts);
+
+	const params = buildV2ListParams({
+		since: options.since ? parseV2DateFilter(options.since, "--since") : undefined,
+		until: options.until ? parseV2DateFilter(options.until, "--until") : undefined,
+		cursor: options.cursor,
+		limit: options.pageSize ? String(validateLimit(options.pageSize)) : undefined,
+	});
+
+	const raw = await client.get<unknown>(`/v2/standups/${numericId}/participation`, params);
+	const parsed = V2StandupParticipationResponseSchema.parse(raw);
 
 	writeOutput(
 		successList(parsed.data, {

--- a/src/schemas/v2-poll.ts
+++ b/src/schemas/v2-poll.ts
@@ -84,3 +84,13 @@ export const V2PollVotesSchema = z.object({
 export type V2PollVotes = z.output<typeof V2PollVotesSchema>;
 
 export const V2PollVotesResponseSchema = v2ItemEnvelope(V2PollVotesSchema);
+
+export const V2PollParticipationSchema = z.object({
+	poll_id: z.number(),
+	is_poll: z.boolean(),
+	date: z.string(),
+	expected: z.number(),
+	responded: z.number(),
+	participation_rate: z.number(),
+});
+export const V2PollParticipationResponseSchema = v2ListEnvelope(V2PollParticipationSchema);

--- a/src/schemas/v2-standup.ts
+++ b/src/schemas/v2-standup.ts
@@ -37,3 +37,14 @@ export type V2Standup = z.output<typeof V2StandupSchema>;
 
 export const V2StandupListResponseSchema = v2ListEnvelope(V2StandupSchema);
 export const V2StandupItemResponseSchema = v2ItemEnvelope(V2StandupSchema);
+
+export const V2StandupParticipationSchema = z.object({
+	standup_id: z.number(),
+	is_poll: z.boolean(),
+	date: z.string(),
+	expected: z.number(),
+	responded: z.number(),
+	participation_rate: z.number(),
+	excluded: z.object({ vacation: z.number() }),
+});
+export const V2StandupParticipationResponseSchema = v2ListEnvelope(V2StandupParticipationSchema);

--- a/tests/cli/commands/poll.test.ts
+++ b/tests/cli/commands/poll.test.ts
@@ -31,14 +31,19 @@ describe("createPollCommand", () => {
 		expect(cmd.name()).toBe("poll");
 	});
 
-	test("registers 4 subcommands", () => {
+	test("registers 5 subcommands", () => {
 		const cmd = createPollCommand();
-		expect(cmd.commands.length).toBe(4);
+		expect(cmd.commands.length).toBe(5);
 	});
 
 	test("registers 'list' subcommand", () => {
 		const cmd = createPollCommand();
 		expect(cmd.commands.find((c) => c.name() === "list")).toBeDefined();
+	});
+
+	test("registers 'participation' subcommand", () => {
+		const cmd = createPollCommand();
+		expect(cmd.commands.find((c) => c.name() === "participation")).toBeDefined();
 	});
 
 	test("registers 'get' subcommand", () => {

--- a/tests/cli/commands/standup.test.ts
+++ b/tests/cli/commands/standup.test.ts
@@ -31,14 +31,19 @@ describe("createStandupCommand", () => {
 		expect(cmd.name()).toBe("standup");
 	});
 
-	test("registers 4 subcommands", () => {
+	test("registers 5 subcommands", () => {
 		const cmd = createStandupCommand();
-		expect(cmd.commands.length).toBe(4);
+		expect(cmd.commands.length).toBe(5);
 	});
 
 	test("registers 'list' subcommand", () => {
 		const cmd = createStandupCommand();
 		expect(cmd.commands.find((c) => c.name() === "list")).toBeDefined();
+	});
+
+	test("registers 'participation' subcommand", () => {
+		const cmd = createStandupCommand();
+		expect(cmd.commands.find((c) => c.name() === "participation")).toBeDefined();
 	});
 
 	test("registers 'get' subcommand", () => {

--- a/tests/handlers/poll-handlers.test.ts
+++ b/tests/handlers/poll-handlers.test.ts
@@ -123,9 +123,13 @@ mock.module("../../src/errors/not-found-helper.ts", () => ({
 	buildNotFoundSuggestion: mockBuildNotFoundSuggestion,
 }));
 
-const { handlePollList, handlePollGet, handlePollCreate, handlePollVotes } = await import(
-	"../../src/handlers/poll-handlers.ts"
-);
+const {
+	handlePollList,
+	handlePollGet,
+	handlePollCreate,
+	handlePollVotes,
+	handlePollParticipation,
+} = await import("../../src/handlers/poll-handlers.ts");
 
 const { CliError } = await import("../../src/errors/cli-error.ts");
 
@@ -339,6 +343,55 @@ describe("handlePollVotes", () => {
 		mockGet.mockImplementation(() => Promise.reject(notFoundError));
 
 		await expect(handlePollVotes("99999", {}, GLOBAL_OPTS)).rejects.toMatchObject({
+			code: "poll_not_found",
+		});
+	});
+});
+
+describe("handlePollParticipation", () => {
+	const PART = {
+		data: [
+			{
+				poll_id: 456,
+				is_poll: true,
+				date: "2026-04-06",
+				expected: 8,
+				responded: 5,
+				participation_rate: 0.625,
+			},
+		],
+		next_cursor: null,
+		has_more: false,
+	};
+
+	test("calls the v2 participation endpoint with mapped params", async () => {
+		mockGet.mockImplementation(() => Promise.resolve(PART));
+		await handlePollParticipation(
+			"456",
+			{ since: "2026-01-01", until: "2026-02-01", cursor: "C2", pageSize: "30" },
+			GLOBAL_OPTS,
+		);
+		expect(mockGet).toHaveBeenCalledWith("/v2/polls/456/participation", {
+			since: "2026-01-01",
+			until: "2026-02-01",
+			cursor: "C2",
+			limit: "30",
+		});
+	});
+
+	test("no params yields an undefined query", async () => {
+		mockGet.mockImplementation(() => Promise.resolve(PART));
+		await handlePollParticipation("456", {}, GLOBAL_OPTS);
+		expect(mockGet).toHaveBeenCalledWith("/v2/polls/456/participation", undefined);
+	});
+
+	test("enriches 404 from the participation path with poll_not_found", async () => {
+		const notFoundError = new CliError("Not found", "not_found", 3, false, undefined, {
+			path: "/v2/polls/99999/participation",
+			status: 404,
+		});
+		mockGet.mockImplementation(() => Promise.reject(notFoundError));
+		await expect(handlePollParticipation("99999", {}, GLOBAL_OPTS)).rejects.toMatchObject({
 			code: "poll_not_found",
 		});
 	});

--- a/tests/handlers/standup-handlers.test.ts
+++ b/tests/handlers/standup-handlers.test.ts
@@ -98,8 +98,13 @@ mock.module("../../src/errors/not-found-helper.ts", () => ({
 }));
 
 // Import handlers AFTER mocks are set up
-const { handleStandupList, handleStandupGet, handleStandupCreate, handleStandupStart } =
-	await import("../../src/handlers/standup-handlers.ts");
+const {
+	handleStandupList,
+	handleStandupGet,
+	handleStandupCreate,
+	handleStandupStart,
+	handleStandupParticipation,
+} = await import("../../src/handlers/standup-handlers.ts");
 
 const { CliError } = await import("../../src/errors/cli-error.ts");
 
@@ -419,5 +424,58 @@ describe("404 suggestion enrichment", () => {
 		}
 
 		expect(mockBuildNotFoundSuggestion).not.toHaveBeenCalled();
+	});
+});
+
+// ── handleStandupParticipation (v2) ──────────────────────────────────
+
+describe("handleStandupParticipation", () => {
+	const PART = {
+		data: [
+			{
+				standup_id: 42,
+				is_poll: false,
+				date: "2026-04-27",
+				expected: 5,
+				responded: 4,
+				participation_rate: 0.8,
+				excluded: { vacation: 1 },
+			},
+		],
+		next_cursor: null,
+		has_more: false,
+	};
+
+	test("calls the v2 participation endpoint with mapped params", async () => {
+		mockGet.mockImplementation(() => Promise.resolve(PART));
+		await handleStandupParticipation(
+			"42",
+			{ since: "2026-01-01", until: "2026-02-01", cursor: "C2", pageSize: "30" },
+			GLOBAL_OPTS,
+		);
+		expect(mockGet).toHaveBeenCalledWith("/v2/standups/42/participation", {
+			since: "2026-01-01",
+			until: "2026-02-01",
+			cursor: "C2",
+			limit: "30",
+		});
+	});
+
+	test("no params yields an undefined query and surfaces pagination metadata", async () => {
+		mockGet.mockImplementation(() => Promise.resolve(PART));
+		await handleStandupParticipation("42", {}, GLOBAL_OPTS);
+		expect(mockGet).toHaveBeenCalledWith("/v2/standups/42/participation", undefined);
+		const envelope = mockWriteOutput.mock.calls[0]?.[0] as {
+			data: Array<{ participation_rate: number }>;
+			metadata: Record<string, unknown>;
+		};
+		expect(envelope.data[0]?.participation_rate).toBe(0.8);
+		expect(envelope.metadata.has_more).toBe(false);
+	});
+
+	test("throws validation error for a non-numeric ID", async () => {
+		await expect(handleStandupParticipation("abc", {}, GLOBAL_OPTS)).rejects.toBeInstanceOf(
+			CliError,
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Wrap the new v2 participation endpoints as two read-only subcommands:

- `geekbot standup participation <id>`
- `geekbot poll participation <id>`

**Flags:** `--since` / `--until` (YYYY-MM-DD or ISO 8601), `--page-size` (default 30), `--cursor`.

Handlers mirror the existing v2 list/votes handlers (poll keeps the Slack-gate + not-found enrichment). Zod schemas via `v2ListEnvelope`; output is the standard receipt envelope with `next_cursor` / `has_more`.

## Changes

- `src/cli/commands/{poll,standup}.ts` — command registration
- `src/handlers/{poll,standup}-handlers.ts` — handlers
- `src/schemas/v2-{poll,standup}.ts` — zod schemas
- README command table/examples + `geekbot-run` skill `cli-commands.md`

## Tests

- Handler tests (incl. poll Slack-gate + not-found enrichment) and command-registration tests
- 75 tests pass locally; coverage 95.62% (pre-push gate ≥95%)