### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "geekbot-cli",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "CLI tool for managing Geekbot standups, reports, and polls — designed for AI agents and humans",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
Bumps `package.json` to **1.1.0** for the `v1.1.0` release (participation commands, #12).

The initial `v1.1.0` release failed to publish because the tag pointed at a commit still carrying `version: 1.0.0`, and npm refuses to republish an existing version. This lands the missing bump so the release tarball is `1.1.0`. After merge, the `v1.1.0` tag/release will be moved onto the merge commit to re-trigger the npm publish.

Semver: additive new subcommands → MINOR bump.