### PR TITLE
chore: bump plugin to 0.2.0, auto-tag releases, document release model

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
 	},
 	"metadata": {
 		"description": "Geekbot CLI — standups, reports, polls from the terminal and AI agents",
-		"version": "0.1.0"
+		"version": "0.2.0"
 	},
 	"plugins": [
 		{

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "geekbot",
 	"description": "Manage Geekbot standups, reports, and polls from Claude via the geekbot CLI",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"author": { "name": "Geekbot" },
 	"homepage": "https://github.com/geekbot-com/geekbot-cli"
 }

--- a/.github/workflows/plugin-tag.yml
+++ b/.github/workflows/plugin-tag.yml
@@ -1,0 +1,60 @@
+name: Tag plugin release
+
+# When the plugin version in .claude-plugin/plugin.json changes on `main`,
+# publish a `geekbot--v<version>` git tag.
+#
+# Claude Code resolves plugin versions by listing `<plugin>--v*` tags and
+# picking the highest, so this tag is what makes a new version discoverable
+# to clients. (Codex tracks the `main` ref directly and needs no tag — it
+# picks the change up on `codex plugin marketplace upgrade`.)
+#
+# The job is idempotent: if the tag already exists it does nothing, so a
+# commit that touches plugin.json without bumping the version is a no-op.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .claude-plugin/plugin.json
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Resolve plugin version
+        id: v
+        run: |
+          version=$(jq -r '.version' .claude-plugin/plugin.json)
+          if [ -z "$version" ] || [ "$version" = "null" ]; then
+            echo "::error::No .version in .claude-plugin/plugin.json"; exit 1
+          fi
+
+          # Mirror `claude plugin tag`: plugin.json and the marketplace
+          # metadata must agree on the version.
+          mkt=$(jq -r '.metadata.version' .claude-plugin/marketplace.json)
+          if [ "$mkt" != "$version" ]; then
+            echo "::error::Version mismatch — plugin.json=$version but marketplace.json metadata.version=$mkt. Bump both."; exit 1
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=geekbot--v${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag (idempotent)
+        run: |
+          tag="${{ steps.v.outputs.tag }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "Tag ${tag} already exists on origin — nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${tag}" -m "geekbot ${{ steps.v.outputs.version }}"
+          git push origin "refs/tags/${tag}"
+          echo "Published ${tag}."

--- a/README.md
+++ b/README.md
@@ -100,6 +100,36 @@ geekbot standup list         # structured JSON on stdout
 
 ---
 
+### Keeping Geekbot up to date
+
+Plugin updates are **pull-based** — when a new version ships, your agent won't pick it up on its own (auto-update is off by default for third-party marketplaces). Refresh it yourself:
+
+<details open>
+<summary><b>Claude Code</b></summary>
+
+```shell
+# Inside Claude Code:
+/plugin marketplace update geekbot-cli
+/reload-plugins
+```
+
+Or turn on auto-update once: run `/plugin` → **Marketplaces** → select `geekbot-cli` → **Enable auto-update**. Claude Code then refreshes after each session starts.
+</details>
+
+<details>
+<summary><b>Codex CLI</b></summary>
+
+```shell
+# Refresh the marketplace snapshot, then re-install to pick up the new version:
+codex plugin marketplace upgrade geekbot-cli
+codex plugin add geekbot@geekbot-cli
+```
+</details>
+
+> The `geekbot` CLI binary updates independently of the plugin: `npm install -g geekbot-cli@latest` (or `bun install -g geekbot-cli`).
+
+---
+
 ## 🛠️ Commands
 
 The CLI follows a `geekbot <resource> <action> [options]` pattern. Run `geekbot <resource> <action> --help` for the full option list on any command. It wraps the Geekbot API — see [developers.geekbot.com](https://developers.geekbot.com) for the underlying endpoints and full data shapes.

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ Then:
 
 Found a bug or have an idea? [Open an issue](https://github.com/geekbot-com/geekbot-cli/issues).
 
+Maintainers: see [RELEASING.md](RELEASING.md) for how the npm CLI and the agent plugin are versioned and published — they're two separate release lines.
+
 ## 📄 License
 
 [MIT](LICENSE) © Geekbot

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,61 @@
+# Releasing
+
+This repo ships **two independent artifacts** with **separate version lines**. Know which one you're releasing.
+
+| Artifact | What it is | Version file | Git tag | Published by |
+|----------|-----------|--------------|---------|--------------|
+| **npm CLI** (`geekbot-cli`) | the `geekbot` binary users install with `npm i -g` | `package.json` | `v<x.y.z>` | `.github/workflows/publish.yml` |
+| **Agent plugin** (`geekbot`) | the Claude Code / Codex plugin (slash commands + skills) | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `plugins/geekbot/.codex-plugin/plugin.json` | `geekbot--v<x.y.z>` | `.github/workflows/plugin-tag.yml` |
+
+The two versions move at their own cadence — a CLI code change bumps the npm version; a skill/README change bumps the plugin version. When a single change touches both, one commit ends up carrying both a `v*` and a `geekbot--v*` tag. That's expected; the tag prefixes keep the two release lines unambiguous.
+
+---
+
+## Releasing the npm CLI
+
+1. Bump `version` in `package.json` (semver: additive = MINOR, fix = PATCH, breaking = MAJOR).
+2. Merge to `main`.
+3. Cut a **GitHub Release** with a tag matching the version (`v1.2.0`), targeting the merge commit.
+4. `publish.yml` fires on `release: published` → runs CI → `npm publish --provenance`.
+
+> npm versions are immutable. The tag must point at a commit whose `package.json` carries a version npm hasn't seen, or the publish fails.
+
+## Releasing the agent plugin
+
+1. Bump the version in **all three** manifests (keep them identical):
+   - `.claude-plugin/plugin.json` → `version`
+   - `.claude-plugin/marketplace.json` → `metadata.version`
+   - `plugins/geekbot/.codex-plugin/plugin.json` → `version`
+2. Merge to `main`.
+3. `plugin-tag.yml` detects the `.claude-plugin/plugin.json` change, verifies the manifests agree, and pushes a `geekbot--v<version>` tag automatically. **No local tagging.**
+
+That's it — no separate publish step. Clients pull from the repo (see below).
+
+> The workflow is idempotent: if `geekbot--v<version>` already exists it's a no-op, so re-merges or non-version edits to `plugin.json` do nothing.
+
+### Cutting the tag manually (fallback)
+
+If you ever need to tag by hand — e.g. the workflow is disabled — it's just a git tag. The `claude` CLI wraps it with manifest validation:
+
+```shell
+claude plugin tag --push          # creates + pushes geekbot--v<version> from the manifests
+# equivalent to:
+git tag -a geekbot--v0.2.0 -m "geekbot 0.2.0" && git push origin refs/tags/geekbot--v0.2.0
+```
+
+Nothing is sent to Anthropic — the tag lives in this GitHub repo; clients read it when they sync the marketplace.
+
+---
+
+## How clients get an update
+
+Updates are **pull-based** — nobody can push a plugin update to users. How they resolve the new version differs by tool:
+
+| Tool | Resolves version by | Picks up a release when… | User refreshes with |
+|------|---------------------|--------------------------|---------------------|
+| **Claude Code** | listing `geekbot--v*` **tags**, highest wins | the **tag** is pushed | `/plugin marketplace update geekbot-cli` + `/reload-plugins` |
+| **Codex** | fetching the marketplace **ref** (default `main`) | the change is **merged to `main`** | `codex plugin marketplace upgrade geekbot-cli` + `codex plugin add geekbot@geekbot-cli` |
+
+So Claude Code needs the tag; Codex only needs the merge. `plugin-tag.yml` covers the Claude Code side automatically, and merging to `main` covers Codex. End-user refresh commands also live in the README's *Keeping Geekbot up to date* section.
+
+Auto-update is **off by default** for third-party marketplaces, so most users won't see a new version until they run the refresh command (or opt into auto-update).

--- a/plugins/geekbot/.codex-plugin/plugin.json
+++ b/plugins/geekbot/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "geekbot",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Manage Geekbot standups, reports, and polls from Codex via the geekbot CLI",
 	"author": { "name": "Geekbot" },
 	"homepage": "https://github.com/geekbot-com/geekbot-cli",


### PR DESCRIPTION
## Changes

**Version bump `0.1.0` → `0.2.0`** across all three manifests (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` `metadata.version`, `plugins/geekbot/.codex-plugin/plugin.json`).

**`.github/workflows/plugin-tag.yml`** — on push to `main`, when `.claude-plugin/plugin.json`'s version changes, pushes a `geekbot--v<version>` git tag (plain `git`+`jq`, idempotent, validates the manifests agree). Claude Code resolves plugin versions from these tags; Codex tracks the `main` ref and needs no tag.

**`RELEASING.md`** — documents the two independent release lines (npm CLI `v*` vs plugin `geekbot--v*`), how each is cut, and how Claude Code (tag-based) vs Codex (ref-based) clients pull updates. Linked from the README Contributing section.

**README** — new *Keeping Geekbot up to date* section with Claude Code + Codex refresh commands.

## After merge

`plugin-tag.yml` will publish `geekbot--v0.2.0` automatically. Users then refresh via `/plugin marketplace update geekbot-cli` + `/reload-plugins` (Codex: `codex plugin marketplace upgrade` + `add`).

> ⚠️ The tag push needs **`contents: write`** — confirm Settings → Actions → Workflow permissions isn't forced read-only, or the tag step will 403.