### PR TITLE
feat: ooo (out-of-office) commands for the v2 API

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
 	},
 	"metadata": {
 		"description": "Geekbot CLI — standups, reports, polls from the terminal and AI agents",
-		"version": "0.2.0"
+		"version": "0.3.0"
 	},
 	"plugins": [
 		{

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "geekbot",
 	"description": "Manage Geekbot standups, reports, and polls from Claude via the geekbot CLI",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"author": { "name": "Geekbot" },
 	"homepage": "https://github.com/geekbot-com/geekbot-cli"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "geekbot-cli",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "CLI tool for managing Geekbot standups, reports, and polls — designed for AI agents and humans",
 	"type": "module",
 	"license": "MIT",

--- a/plugins/geekbot/.codex-plugin/plugin.json
+++ b/plugins/geekbot/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "geekbot",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Manage Geekbot standups, reports, and polls from Codex via the geekbot CLI",
 	"author": { "name": "Geekbot" },
 	"homepage": "https://github.com/geekbot-com/geekbot-cli",

--- a/skills/geekbot-run/SKILL.md
+++ b/skills/geekbot-run/SKILL.md
@@ -97,6 +97,8 @@ Most common operations at a glance:
 | List reports | `geekbot report list --standup-id <id> --limit 10` |
 | Submit a report | `geekbot report create --standup-id <id> --answers '{"<qid>":"..."}'` |
 | My profile + user ID | `geekbot me show` |
+| Set out-of-office (pauses standups) | `geekbot ooo create --start-date "YYYY-MM-DD" --end-date "YYYY-MM-DD"` (admins add `--user <id>` for another member) |
+| List/adjust out-of-office periods | `geekbot ooo list`, `geekbot ooo edit <id> --end-date "..."`, `geekbot ooo delete <id> --yes` |
 | Create a poll (Slack only) | `geekbot poll create --name "..." --channel "..." --question "..." --choices '[...]' [--duration 120]` |
 | Search team members | `geekbot team search <query>` (matches username, realname, email) |
 | Check auth | `geekbot auth status` |
@@ -148,6 +150,9 @@ The same person can manage standups and submit reports in one conversation.
 - Context language: "what did I say last time", "carry over blockers",
   "my recent reports"
 - Identity queries: "what standups am I in", "show my profile"
+- Out-of-office language: "I'm on vacation", "out of office", "OOO",
+  "pause my standups while I'm away" — use the `geekbot ooo` commands
+  (managers can set OOO for a member with `--user <id>`)
 
 **When ambiguous**, ask one clarifying question — never more than one.
 Use `[PICKER]` if the disambiguation is between 2–4 named options

--- a/skills/geekbot-run/cli-commands.md
+++ b/skills/geekbot-run/cli-commands.md
@@ -340,19 +340,22 @@ each entry is independent.
 
 ### ooo list
 
-List current and upcoming periods (past periods are not returned) via
-`GET /v2/ooo`. Cursor-paginated, ordered by start date.
+List out-of-office periods via `GET /v2/ooo`. By default only current and
+upcoming periods are returned; pass `--include-past` for the full history.
+Cursor-paginated, ordered by start date.
 
 ```bash
-geekbot ooo list                          # your own periods
-geekbot ooo list --user U08LXSA31BJ       # another member's (admin)
+geekbot ooo list                          # your own current + upcoming periods
+geekbot ooo list --include-past           # full history, past periods included
+geekbot ooo list --user U08LXSA31BJ       # another member's
 geekbot ooo list --page-size 50           # larger page
 geekbot ooo list --cursor "<token>"       # next page
 ```
 
 | Flag | Default | Notes |
 |------|---------|-------|
-| `--user <id>` | you | Slack-style user ID; admins listing another member |
+| `--user <id>` | you | Slack-style user ID; admins can list anyone, members can list teammates they share an active standup with |
+| `--include-past` | off | Include periods that have already ended |
 | `--cursor <token>` | — | Opaque pagination cursor from a previous response |
 | `--page-size <n>` | `25` | Page size (1-100) |
 

--- a/skills/geekbot-run/cli-commands.md
+++ b/skills/geekbot-run/cli-commands.md
@@ -8,9 +8,10 @@ JSON envelope: `{ ok, data, error, metadata }`. Always check `ok` first.
 1. [Standup commands](#standup)
 2. [Report commands](#report)
 3. [Poll commands](#poll)
-4. [Identity commands](#identity)
-5. [Auth commands](#auth)
-6. [Global options](#global-options)
+4. [Out-of-office commands](#out-of-office)
+5. [Identity commands](#identity)
+6. [Auth commands](#auth)
+7. [Global options](#global-options)
 
 ---
 
@@ -325,6 +326,111 @@ Returns: `data` is an array of per-broadcast entries, newest-first. Each has
 `poll_id`, `date`, `expected` (recipients), `responded` (distinct voters), and
 `participation_rate` (0-1). A rate above 1.0 means more people voted than the
 poll's current members — a sign it needs syncing.
+
+---
+
+## Out of office
+
+Out-of-office periods pause standup notifications for a user while they are
+away — the same periods a user sets by messaging `ooo` to the Geekbot bot.
+By default commands operate on the authenticated user; admins can manage
+another member's periods with `--user <id>` (Slack-style ID). All dates are
+`YYYY-MM-DD`; `end_date` is inclusive. Overlapping periods are allowed —
+each entry is independent.
+
+### ooo list
+
+List current and upcoming periods (past periods are not returned) via
+`GET /v2/ooo`. Cursor-paginated, ordered by start date.
+
+```bash
+geekbot ooo list                          # your own periods
+geekbot ooo list --user U08LXSA31BJ       # another member's (admin)
+geekbot ooo list --page-size 50           # larger page
+geekbot ooo list --cursor "<token>"       # next page
+```
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--user <id>` | you | Slack-style user ID; admins listing another member |
+| `--cursor <token>` | — | Opaque pagination cursor from a previous response |
+| `--page-size <n>` | `25` | Page size (1-100) |
+
+Returns: `data` is an array of OOO period objects `{ id, user_id,
+start_date, end_date, days, timezone, created_at }`; `metadata.next_cursor`
+and `metadata.has_more` drive pagination.
+
+### ooo get
+
+Get a single period by ID via `GET /v2/ooo/{id}`.
+
+```bash
+geekbot ooo get 12
+geekbot ooo get 12 --user U08LXSA31BJ
+```
+
+| Flag | Notes |
+|------|-------|
+| `--user <id>` | Slack-style user ID; admins reading another member's period |
+
+### ooo create
+
+Create a period via `POST /v2/ooo`. Both dates are required.
+
+```bash
+geekbot ooo create --start-date "2026-08-01" --end-date "2026-08-15"
+
+# Admin: set OOO for another member
+geekbot ooo create --start-date "2026-08-01" --end-date "2026-08-15" \
+  --user U08LXSA31BJ
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--start-date <date>` | Yes | First day out (`YYYY-MM-DD`), must be <= end date |
+| `--end-date <date>` | Yes | Last day out (`YYYY-MM-DD`, inclusive), must not be in the past |
+| `--user <id>` | No | Slack-style user ID; admins creating for another member |
+
+**Idempotency:** same behavior as `standup create` — UUID auto-generated per
+call, 24h API window. Don't re-run on ambiguous outcomes; list first with
+`geekbot ooo list`.
+
+Returns: `data` is the created period. `metadata.undo` contains the matching
+`geekbot ooo delete <id> --yes` command.
+
+### ooo edit
+
+Change the dates of a period via `PATCH /v2/ooo/{id}`. At least one of the
+two date flags is required.
+
+```bash
+geekbot ooo edit 12 --end-date "2026-08-20"
+geekbot ooo edit 12 --start-date "2026-08-03" --end-date "2026-08-20"
+geekbot ooo edit 12 --end-date "2026-08-20" --user U08LXSA31BJ
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--start-date <date>` | No¹ | New first day out (`YYYY-MM-DD`) |
+| `--end-date <date>` | No¹ | New last day out (`YYYY-MM-DD`, inclusive) |
+| `--user <id>` | No | Slack-style user ID; admins editing another member's period |
+
+¹ At least one of `--start-date` / `--end-date` must be provided.
+
+### ooo delete
+
+Delete a period via `DELETE /v2/ooo/{id}`, resuming standup notifications
+for those dates. Requires `--yes` confirmation.
+
+```bash
+geekbot ooo delete 12 --yes
+geekbot ooo delete 12 --user U08LXSA31BJ --yes
+```
+
+| Flag | Notes |
+|------|-------|
+| `--user <id>` | Slack-style user ID; admins deleting another member's period |
+| `--yes` | Confirm deletion (required) |
 
 ---
 

--- a/skills/geekbot-run/cli-commands.md
+++ b/skills/geekbot-run/cli-commands.md
@@ -341,12 +341,15 @@ each entry is independent.
 ### ooo list
 
 List out-of-office periods via `GET /v2/ooo`. By default only current and
-upcoming periods are returned; pass `--include-past` for the full history.
-Cursor-paginated, ordered by start date.
+upcoming periods are returned; `--after`/`--before` bound the date window
+like `report list` (a period matches when it overlaps the window), so an
+`--after` in the past retrieves historical periods. Cursor-paginated,
+ordered by start date.
 
 ```bash
 geekbot ooo list                          # your own current + upcoming periods
-geekbot ooo list --include-past           # full history, past periods included
+geekbot ooo list --after 2026-01-01       # history since Jan 1 (plus upcoming)
+geekbot ooo list --after 2026-01-01 --before 2026-07-01   # bounded window
 geekbot ooo list --user U08LXSA31BJ       # another member's
 geekbot ooo list --page-size 50           # larger page
 geekbot ooo list --cursor "<token>"       # next page
@@ -355,7 +358,8 @@ geekbot ooo list --cursor "<token>"       # next page
 | Flag | Default | Notes |
 |------|---------|-------|
 | `--user <id>` | you | Slack-style user ID; admins can list anyone, members can list teammates they share an active standup with |
-| `--include-past` | off | Include periods that have already ended |
+| `--after <date>` | now | Only periods ending on/after this date (v2 `since`, inclusive) — set a past date for history |
+| `--before <date>` | — | Only periods starting before this date (v2 `until`, exclusive) |
 | `--cursor <token>` | — | Opaque pagination cursor from a previous response |
 | `--page-size <n>` | `25` | Page size (1-100) |
 
@@ -369,12 +373,7 @@ Get a single period by ID via `GET /v2/ooo/{id}`.
 
 ```bash
 geekbot ooo get 12
-geekbot ooo get 12 --user U08LXSA31BJ
 ```
-
-| Flag | Notes |
-|------|-------|
-| `--user <id>` | Slack-style user ID; admins reading another member's period |
 
 ### ooo create
 
@@ -409,14 +408,12 @@ two date flags is required.
 ```bash
 geekbot ooo edit 12 --end-date "2026-08-20"
 geekbot ooo edit 12 --start-date "2026-08-03" --end-date "2026-08-20"
-geekbot ooo edit 12 --end-date "2026-08-20" --user U08LXSA31BJ
 ```
 
 | Flag | Required | Notes |
 |------|----------|-------|
 | `--start-date <date>` | No¹ | New first day out (`YYYY-MM-DD`) |
 | `--end-date <date>` | No¹ | New last day out (`YYYY-MM-DD`, inclusive) |
-| `--user <id>` | No | Slack-style user ID; admins editing another member's period |
 
 ¹ At least one of `--start-date` / `--end-date` must be provided.
 
@@ -427,12 +424,10 @@ for those dates. Requires `--yes` confirmation.
 
 ```bash
 geekbot ooo delete 12 --yes
-geekbot ooo delete 12 --user U08LXSA31BJ --yes
 ```
 
 | Flag | Notes |
 |------|-------|
-| `--user <id>` | Slack-style user ID; admins deleting another member's period |
 | `--yes` | Confirm deletion (required) |
 
 ---

--- a/src/cli/commands/ooo.ts
+++ b/src/cli/commands/ooo.ts
@@ -1,0 +1,140 @@
+import { Command } from "commander";
+import { handleError } from "../../errors/error-handler.ts";
+import {
+	handleOooCreate,
+	handleOooDelete,
+	handleOooEdit,
+	handleOooGet,
+	handleOooList,
+} from "../../handlers/ooo-handlers.ts";
+import { getGlobalOptions } from "../globals.ts";
+
+export function createOooCommand(): Command {
+	const ooo = new Command("ooo").description(
+		"Manage out-of-office periods that pause standup notifications (same periods as the bot's ooo command)",
+	);
+
+	ooo
+		.command("list")
+		.description("List current and upcoming out-of-office periods (v2)")
+		.option("--user <id>", "Slack-style user ID (admins listing another member, e.g. U123)")
+		.option("--cursor <token>", "Opaque pagination cursor from a previous response")
+		.option("--page-size <n>", "Page size (1-100, default 25)")
+		.addHelpText(
+			"after",
+			'\nExamples:\n  geekbot ooo list\n  geekbot ooo list --user U08LXSA31BJ\n  geekbot ooo list --page-size 50\n  geekbot ooo list --cursor "<token>"',
+		)
+		.action(async function (this: Command) {
+			const globalOpts = getGlobalOptions(this);
+			try {
+				const opts = this.opts();
+				await handleOooList(
+					{
+						user: opts.user,
+						cursor: opts.cursor,
+						pageSize: opts.pageSize,
+					},
+					globalOpts,
+				);
+			} catch (error) {
+				handleError(error);
+			}
+		});
+
+	ooo
+		.command("get")
+		.description("Get an out-of-office period by ID (v2)")
+		.argument("<oooId>", "OOO period ID (numeric)")
+		.option("--user <id>", "Slack-style user ID (admins reading another member's period)")
+		.addHelpText(
+			"after",
+			"\nExamples:\n  geekbot ooo get 12\n  geekbot ooo get 12 --user U08LXSA31BJ",
+		)
+		.action(async function (this: Command, oooId: string) {
+			const globalOpts = getGlobalOptions(this);
+			try {
+				const opts = this.opts();
+				await handleOooGet(oooId, { user: opts.user }, globalOpts);
+			} catch (error) {
+				handleError(error);
+			}
+		});
+
+	ooo
+		.command("create")
+		.description("Create an out-of-office period that pauses standup notifications (v2)")
+		.requiredOption("--start-date <date>", "First day out of office (YYYY-MM-DD)")
+		.requiredOption("--end-date <date>", "Last day out of office (YYYY-MM-DD, inclusive)")
+		.option("--user <id>", "Slack-style user ID (admins creating for another member)")
+		.addHelpText(
+			"after",
+			'\nExamples:\n  geekbot ooo create --start-date "2026-08-01" --end-date "2026-08-15"\n  geekbot ooo create --start-date "2026-08-01" --end-date "2026-08-15" --user U08LXSA31BJ',
+		)
+		.action(async function (this: Command) {
+			const globalOpts = getGlobalOptions(this);
+			try {
+				const opts = this.opts();
+				await handleOooCreate(
+					{
+						startDate: opts.startDate,
+						endDate: opts.endDate,
+						user: opts.user,
+					},
+					globalOpts,
+				);
+			} catch (error) {
+				handleError(error);
+			}
+		});
+
+	ooo
+		.command("edit")
+		.description("Change the dates of an out-of-office period (v2)")
+		.argument("<oooId>", "OOO period ID (numeric)")
+		.option("--start-date <date>", "New first day out of office (YYYY-MM-DD)")
+		.option("--end-date <date>", "New last day out of office (YYYY-MM-DD, inclusive)")
+		.option("--user <id>", "Slack-style user ID (admins editing another member's period)")
+		.addHelpText(
+			"after",
+			'\nExamples:\n  geekbot ooo edit 12 --end-date "2026-08-20"\n  geekbot ooo edit 12 --start-date "2026-08-03" --end-date "2026-08-20"\n  geekbot ooo edit 12 --end-date "2026-08-20" --user U08LXSA31BJ',
+		)
+		.action(async function (this: Command, oooId: string) {
+			const globalOpts = getGlobalOptions(this);
+			try {
+				const opts = this.opts();
+				await handleOooEdit(
+					oooId,
+					{
+						startDate: opts.startDate,
+						endDate: opts.endDate,
+						user: opts.user,
+					},
+					globalOpts,
+				);
+			} catch (error) {
+				handleError(error);
+			}
+		});
+
+	ooo
+		.command("delete")
+		.description("Delete an out-of-office period, resuming standup notifications (v2)")
+		.argument("<oooId>", "OOO period ID (numeric)")
+		.option("--user <id>", "Slack-style user ID (admins deleting another member's period)")
+		.option("--yes", "Confirm deletion (required)")
+		.addHelpText(
+			"after",
+			"\nExamples:\n  geekbot ooo delete 12 --yes\n  geekbot ooo delete 12 --user U08LXSA31BJ --yes",
+		)
+		.action(async function (this: Command, oooId: string) {
+			const globalOpts = getGlobalOptions(this);
+			try {
+				const opts = this.opts();
+				await handleOooDelete(oooId, { user: opts.user, yes: opts.yes }, globalOpts);
+			} catch (error) {
+				handleError(error);
+			}
+		});
+
+	return ooo;
+}

--- a/src/cli/commands/ooo.ts
+++ b/src/cli/commands/ooo.ts
@@ -20,9 +20,13 @@ export function createOooCommand(): Command {
 		.option("--user <id>", "Slack-style user ID (admins listing another member, e.g. U123)")
 		.option("--cursor <token>", "Opaque pagination cursor from a previous response")
 		.option("--page-size <n>", "Page size (1-100, default 25)")
+		.option(
+			"--include-past",
+			"Include periods that have already ended (default: current + upcoming only)",
+		)
 		.addHelpText(
 			"after",
-			'\nExamples:\n  geekbot ooo list\n  geekbot ooo list --user U08LXSA31BJ\n  geekbot ooo list --page-size 50\n  geekbot ooo list --cursor "<token>"',
+			'\nExamples:\n  geekbot ooo list\n  geekbot ooo list --user U08LXSA31BJ\n  geekbot ooo list --include-past\n  geekbot ooo list --page-size 50\n  geekbot ooo list --cursor "<token>"',
 		)
 		.action(async function (this: Command) {
 			const globalOpts = getGlobalOptions(this);
@@ -33,6 +37,7 @@ export function createOooCommand(): Command {
 						user: opts.user,
 						cursor: opts.cursor,
 						pageSize: opts.pageSize,
+						includePast: opts.includePast,
 					},
 					globalOpts,
 				);

--- a/src/cli/commands/ooo.ts
+++ b/src/cli/commands/ooo.ts
@@ -21,12 +21,16 @@ export function createOooCommand(): Command {
 		.option("--cursor <token>", "Opaque pagination cursor from a previous response")
 		.option("--page-size <n>", "Page size (1-100, default 25)")
 		.option(
-			"--include-past",
-			"Include periods that have already ended (default: current + upcoming only)",
+			"--after <date>",
+			"Periods ending on/after date (maps to v2 'since' — YYYY-MM-DD or ISO 8601; default: now)",
+		)
+		.option(
+			"--before <date>",
+			"Periods starting before date (maps to v2 'until' — YYYY-MM-DD or ISO 8601)",
 		)
 		.addHelpText(
 			"after",
-			'\nExamples:\n  geekbot ooo list\n  geekbot ooo list --user U08LXSA31BJ\n  geekbot ooo list --include-past\n  geekbot ooo list --page-size 50\n  geekbot ooo list --cursor "<token>"',
+			'\nExamples:\n  geekbot ooo list\n  geekbot ooo list --user U08LXSA31BJ\n  geekbot ooo list --after 2026-01-01 --before 2026-07-01\n  geekbot ooo list --page-size 50\n  geekbot ooo list --cursor "<token>"',
 		)
 		.action(async function (this: Command) {
 			const globalOpts = getGlobalOptions(this);
@@ -37,7 +41,8 @@ export function createOooCommand(): Command {
 						user: opts.user,
 						cursor: opts.cursor,
 						pageSize: opts.pageSize,
-						includePast: opts.includePast,
+						after: opts.after,
+						before: opts.before,
 					},
 					globalOpts,
 				);
@@ -50,16 +55,11 @@ export function createOooCommand(): Command {
 		.command("get")
 		.description("Get an out-of-office period by ID (v2)")
 		.argument("<oooId>", "OOO period ID (numeric)")
-		.option("--user <id>", "Slack-style user ID (admins reading another member's period)")
-		.addHelpText(
-			"after",
-			"\nExamples:\n  geekbot ooo get 12\n  geekbot ooo get 12 --user U08LXSA31BJ",
-		)
+		.addHelpText("after", "\nExamples:\n  geekbot ooo get 12")
 		.action(async function (this: Command, oooId: string) {
 			const globalOpts = getGlobalOptions(this);
 			try {
-				const opts = this.opts();
-				await handleOooGet(oooId, { user: opts.user }, globalOpts);
+				await handleOooGet(oooId, globalOpts);
 			} catch (error) {
 				handleError(error);
 			}
@@ -98,10 +98,9 @@ export function createOooCommand(): Command {
 		.argument("<oooId>", "OOO period ID (numeric)")
 		.option("--start-date <date>", "New first day out of office (YYYY-MM-DD)")
 		.option("--end-date <date>", "New last day out of office (YYYY-MM-DD, inclusive)")
-		.option("--user <id>", "Slack-style user ID (admins editing another member's period)")
 		.addHelpText(
 			"after",
-			'\nExamples:\n  geekbot ooo edit 12 --end-date "2026-08-20"\n  geekbot ooo edit 12 --start-date "2026-08-03" --end-date "2026-08-20"\n  geekbot ooo edit 12 --end-date "2026-08-20" --user U08LXSA31BJ',
+			'\nExamples:\n  geekbot ooo edit 12 --end-date "2026-08-20"\n  geekbot ooo edit 12 --start-date "2026-08-03" --end-date "2026-08-20"',
 		)
 		.action(async function (this: Command, oooId: string) {
 			const globalOpts = getGlobalOptions(this);
@@ -112,7 +111,6 @@ export function createOooCommand(): Command {
 					{
 						startDate: opts.startDate,
 						endDate: opts.endDate,
-						user: opts.user,
 					},
 					globalOpts,
 				);
@@ -125,17 +123,13 @@ export function createOooCommand(): Command {
 		.command("delete")
 		.description("Delete an out-of-office period, resuming standup notifications (v2)")
 		.argument("<oooId>", "OOO period ID (numeric)")
-		.option("--user <id>", "Slack-style user ID (admins deleting another member's period)")
 		.option("--yes", "Confirm deletion (required)")
-		.addHelpText(
-			"after",
-			"\nExamples:\n  geekbot ooo delete 12 --yes\n  geekbot ooo delete 12 --user U08LXSA31BJ --yes",
-		)
+		.addHelpText("after", "\nExamples:\n  geekbot ooo delete 12 --yes")
 		.action(async function (this: Command, oooId: string) {
 			const globalOpts = getGlobalOptions(this);
 			try {
 				const opts = this.opts();
-				await handleOooDelete(oooId, { user: opts.user, yes: opts.yes }, globalOpts);
+				await handleOooDelete(oooId, { yes: opts.yes }, globalOpts);
 			} catch (error) {
 				handleError(error);
 			}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { ExitCode } from "../errors/exit-codes.ts";
 import { APP_NAME, APP_VERSION } from "../utils/constants.ts";
 import { createAuthCommand } from "./commands/auth.ts";
 import { createMeCommand } from "./commands/me.ts";
+import { createOooCommand } from "./commands/ooo.ts";
 import { createPollCommand } from "./commands/poll.ts";
 import { createReportCommand } from "./commands/report.ts";
 import { createStandupCommand } from "./commands/standup.ts";
@@ -47,6 +48,7 @@ export function createProgram(): Command {
 	program.addCommand(createStandupCommand());
 	program.addCommand(createReportCommand());
 	program.addCommand(createPollCommand());
+	program.addCommand(createOooCommand());
 	program.addCommand(createAuthCommand());
 	program.addCommand(createMeCommand());
 	program.addCommand(createTeamCommand());

--- a/src/handlers/ooo-handlers.ts
+++ b/src/handlers/ooo-handlers.ts
@@ -16,6 +16,7 @@ export interface OooListOptions {
 	user?: string;
 	cursor?: string;
 	pageSize?: string;
+	includePast?: boolean;
 }
 
 export interface OooGetOptions {
@@ -90,6 +91,7 @@ export async function handleOooList(
 		user_id: options.user ? validateSlackId(options.user, "user ID") : undefined,
 		cursor: options.cursor,
 		limit: options.pageSize ? String(validateLimit(options.pageSize)) : undefined,
+		include_past: options.includePast === true ? "true" : undefined,
 	});
 
 	const raw = await client.get<unknown>("/v2/ooo", params);

--- a/src/handlers/ooo-handlers.ts
+++ b/src/handlers/ooo-handlers.ts
@@ -6,7 +6,7 @@ import { idempotencyHeader } from "../http/idempotency.ts";
 import { success, successList } from "../output/envelope.ts";
 import { writeOutput } from "../output/formatter.ts";
 import { V2OooItemResponseSchema, V2OooListResponseSchema } from "../schemas/v2-ooo.ts";
-import { parseDateFilter } from "../utils/input-parsers.ts";
+import { parseDateFilter, parseV2DateFilter } from "../utils/input-parsers.ts";
 import { buildReceipt } from "../utils/receipt.ts";
 import { validateLimit, validateNumericId, validateSlackId } from "../utils/validation.ts";
 
@@ -16,11 +16,8 @@ export interface OooListOptions {
 	user?: string;
 	cursor?: string;
 	pageSize?: string;
-	includePast?: boolean;
-}
-
-export interface OooGetOptions {
-	user?: string;
+	after?: string;
+	before?: string;
 }
 
 export interface OooCreateOptions {
@@ -32,11 +29,9 @@ export interface OooCreateOptions {
 export interface OooEditOptions {
 	startDate?: string;
 	endDate?: string;
-	user?: string;
 }
 
 export interface OooDeleteOptions {
-	user?: string;
 	yes?: boolean;
 }
 
@@ -79,7 +74,8 @@ function buildParams(
 /**
  * Handle `geekbot ooo list` command.
  * Fetches out-of-office periods from GET /v2/ooo (cursor-paginated, single
- * page per call). Only current and upcoming periods are returned by the API.
+ * page per call). Without a date window the API returns current and upcoming
+ * periods; `--after`/`--before` map to v2 `since`/`until` like `report list`.
  */
 export async function handleOooList(
 	options: OooListOptions,
@@ -91,7 +87,8 @@ export async function handleOooList(
 		user_id: options.user ? validateSlackId(options.user, "user ID") : undefined,
 		cursor: options.cursor,
 		limit: options.pageSize ? String(validateLimit(options.pageSize)) : undefined,
-		include_past: options.includePast === true ? "true" : undefined,
+		since: options.after ? parseV2DateFilter(options.after, "--after") : undefined,
+		until: options.before ? parseV2DateFilter(options.before, "--before") : undefined,
 	});
 
 	const raw = await client.get<unknown>("/v2/ooo", params);
@@ -109,19 +106,11 @@ export async function handleOooList(
  * Handle `geekbot ooo get` command.
  * Fetches a single out-of-office period via GET /v2/ooo/{id}.
  */
-export async function handleOooGet(
-	id: string,
-	options: OooGetOptions,
-	globalOpts: GlobalOptions,
-): Promise<void> {
+export async function handleOooGet(id: string, globalOpts: GlobalOptions): Promise<void> {
 	const client = await createAuthenticatedClient(globalOpts);
 	const numericId = validateNumericId(id, "OOO period ID");
 
-	const params = buildParams({
-		user_id: options.user ? validateSlackId(options.user, "user ID") : undefined,
-	});
-
-	const raw = await client.get<unknown>(`/v2/ooo/${numericId}`, params);
+	const raw = await client.get<unknown>(`/v2/ooo/${numericId}`);
 	const parsed = V2OooItemResponseSchema.parse(raw);
 	writeOutput(success(parsed.data));
 }
@@ -148,8 +137,7 @@ export async function handleOooCreate(
 
 	const raw = await client.post<unknown>("/v2/ooo", body, idempotencyHeader());
 	const parsed = V2OooItemResponseSchema.parse(raw);
-	const undoUser = options.user !== undefined ? ` --user ${options.user}` : "";
-	const receipt = buildReceipt("created", `geekbot ooo delete ${parsed.data.id}${undoUser} --yes`);
+	const receipt = buildReceipt("created", `geekbot ooo delete ${parsed.data.id} --yes`);
 
 	writeOutput(success(parsed.data, receipt));
 }
@@ -185,9 +173,6 @@ export async function handleOooEdit(
 	if (options.endDate !== undefined) {
 		body.end_date = validateOooDate(options.endDate, "--end-date");
 	}
-	if (options.user !== undefined) {
-		body.user_id = validateSlackId(options.user, "user ID");
-	}
 
 	const raw = await client.patch<unknown>(`/v2/ooo/${numericId}`, body, idempotencyHeader());
 	const parsed = V2OooItemResponseSchema.parse(raw);
@@ -199,8 +184,7 @@ export async function handleOooEdit(
 /**
  * Handle `geekbot ooo delete` command.
  * Deletes an out-of-office period via DELETE /v2/ooo/{id}. Requires `--yes`
- * confirmation. The optional `user_id` query param is appended to the path
- * because HttpClient.delete does not accept query params.
+ * confirmation.
  */
 export async function handleOooDelete(
 	id: string,
@@ -219,13 +203,8 @@ export async function handleOooDelete(
 		);
 	}
 
-	let path = `/v2/ooo/${numericId}`;
-	if (options.user !== undefined) {
-		path += `?user_id=${validateSlackId(options.user, "user ID")}`;
-	}
-
 	const client = await createAuthenticatedClient(globalOpts);
-	await client.delete(path, idempotencyHeader());
+	await client.delete(`/v2/ooo/${numericId}`, idempotencyHeader());
 	const receipt = buildReceipt("deleted", null);
 	writeOutput(success({ id: numericId }, receipt));
 }

--- a/src/handlers/ooo-handlers.ts
+++ b/src/handlers/ooo-handlers.ts
@@ -1,0 +1,229 @@
+import type { GlobalOptions } from "../cli/globals.ts";
+import { CliError } from "../errors/cli-error.ts";
+import { ExitCode } from "../errors/exit-codes.ts";
+import { createAuthenticatedClient } from "../http/authenticated-client.ts";
+import { idempotencyHeader } from "../http/idempotency.ts";
+import { success, successList } from "../output/envelope.ts";
+import { writeOutput } from "../output/formatter.ts";
+import { V2OooItemResponseSchema, V2OooListResponseSchema } from "../schemas/v2-ooo.ts";
+import { parseDateFilter } from "../utils/input-parsers.ts";
+import { buildReceipt } from "../utils/receipt.ts";
+import { validateLimit, validateNumericId, validateSlackId } from "../utils/validation.ts";
+
+// ── Option Interfaces ─────────────────────────────────────────────────
+
+export interface OooListOptions {
+	user?: string;
+	cursor?: string;
+	pageSize?: string;
+}
+
+export interface OooGetOptions {
+	user?: string;
+}
+
+export interface OooCreateOptions {
+	startDate: string;
+	endDate: string;
+	user?: string;
+}
+
+export interface OooEditOptions {
+	startDate?: string;
+	endDate?: string;
+	user?: string;
+}
+
+export interface OooDeleteOptions {
+	user?: string;
+	yes?: boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Validate an out-of-office date flag (strict YYYY-MM-DD, real calendar date).
+ * Returns the input unchanged so it can be sent to the API as-is.
+ */
+function validateOooDate(raw: string, flag: string): string {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+		throw new CliError(
+			`Invalid date for ${flag}: "${raw}".`,
+			"validation_error",
+			ExitCode.VALIDATION,
+			false,
+			`Use YYYY-MM-DD, e.g.: ${flag} "2026-08-01"`,
+		);
+	}
+	// Reuse parseDateFilter's calendar validation (rejects e.g. 2026-02-31);
+	// discard its unix-timestamp output.
+	parseDateFilter(raw, flag);
+	return raw;
+}
+
+function buildParams(
+	input: Record<string, string | undefined>,
+): Record<string, string> | undefined {
+	const out: Record<string, string> = {};
+	for (const [k, v] of Object.entries(input)) {
+		if (v !== undefined && v !== "") {
+			out[k] = v;
+		}
+	}
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────
+
+/**
+ * Handle `geekbot ooo list` command.
+ * Fetches out-of-office periods from GET /v2/ooo (cursor-paginated, single
+ * page per call). Only current and upcoming periods are returned by the API.
+ */
+export async function handleOooList(
+	options: OooListOptions,
+	globalOpts: GlobalOptions,
+): Promise<void> {
+	const client = await createAuthenticatedClient(globalOpts);
+
+	const params = buildParams({
+		user_id: options.user ? validateSlackId(options.user, "user ID") : undefined,
+		cursor: options.cursor,
+		limit: options.pageSize ? String(validateLimit(options.pageSize)) : undefined,
+	});
+
+	const raw = await client.get<unknown>("/v2/ooo", params);
+	const parsed = V2OooListResponseSchema.parse(raw);
+
+	writeOutput(
+		successList(parsed.data, {
+			next_cursor: parsed.next_cursor,
+			has_more: parsed.has_more,
+		}),
+	);
+}
+
+/**
+ * Handle `geekbot ooo get` command.
+ * Fetches a single out-of-office period via GET /v2/ooo/{id}.
+ */
+export async function handleOooGet(
+	id: string,
+	options: OooGetOptions,
+	globalOpts: GlobalOptions,
+): Promise<void> {
+	const client = await createAuthenticatedClient(globalOpts);
+	const numericId = validateNumericId(id, "OOO period ID");
+
+	const params = buildParams({
+		user_id: options.user ? validateSlackId(options.user, "user ID") : undefined,
+	});
+
+	const raw = await client.get<unknown>(`/v2/ooo/${numericId}`, params);
+	const parsed = V2OooItemResponseSchema.parse(raw);
+	writeOutput(success(parsed.data));
+}
+
+/**
+ * Handle `geekbot ooo create` command.
+ * Creates an out-of-office period via POST /v2/ooo with an auto-generated
+ * Idempotency-Key.
+ */
+export async function handleOooCreate(
+	options: OooCreateOptions,
+	globalOpts: GlobalOptions,
+): Promise<void> {
+	const client = await createAuthenticatedClient(globalOpts);
+
+	const body: Record<string, unknown> = {
+		start_date: validateOooDate(options.startDate, "--start-date"),
+		end_date: validateOooDate(options.endDate, "--end-date"),
+	};
+
+	if (options.user !== undefined) {
+		body.user_id = validateSlackId(options.user, "user ID");
+	}
+
+	const raw = await client.post<unknown>("/v2/ooo", body, idempotencyHeader());
+	const parsed = V2OooItemResponseSchema.parse(raw);
+	const undoUser = options.user !== undefined ? ` --user ${options.user}` : "";
+	const receipt = buildReceipt("created", `geekbot ooo delete ${parsed.data.id}${undoUser} --yes`);
+
+	writeOutput(success(parsed.data, receipt));
+}
+
+/**
+ * Handle `geekbot ooo edit` command.
+ * Updates an out-of-office period via PATCH /v2/ooo/{id}. At least one of
+ * the two date flags is required.
+ */
+export async function handleOooEdit(
+	id: string,
+	options: OooEditOptions,
+	globalOpts: GlobalOptions,
+): Promise<void> {
+	const numericId = validateNumericId(id, "OOO period ID");
+
+	if (options.startDate === undefined && options.endDate === undefined) {
+		throw new CliError(
+			"At least one of --start-date or --end-date is required.",
+			"validation_error",
+			ExitCode.VALIDATION,
+			false,
+			'Example: geekbot ooo edit 12 --end-date "2026-08-15"',
+		);
+	}
+
+	const client = await createAuthenticatedClient(globalOpts);
+
+	const body: Record<string, unknown> = {};
+	if (options.startDate !== undefined) {
+		body.start_date = validateOooDate(options.startDate, "--start-date");
+	}
+	if (options.endDate !== undefined) {
+		body.end_date = validateOooDate(options.endDate, "--end-date");
+	}
+	if (options.user !== undefined) {
+		body.user_id = validateSlackId(options.user, "user ID");
+	}
+
+	const raw = await client.patch<unknown>(`/v2/ooo/${numericId}`, body, idempotencyHeader());
+	const parsed = V2OooItemResponseSchema.parse(raw);
+	const receipt = buildReceipt("updated", null);
+
+	writeOutput(success(parsed.data, receipt));
+}
+
+/**
+ * Handle `geekbot ooo delete` command.
+ * Deletes an out-of-office period via DELETE /v2/ooo/{id}. Requires `--yes`
+ * confirmation. The optional `user_id` query param is appended to the path
+ * because HttpClient.delete does not accept query params.
+ */
+export async function handleOooDelete(
+	id: string,
+	options: OooDeleteOptions,
+	globalOpts: GlobalOptions,
+): Promise<void> {
+	const numericId = validateNumericId(id, "OOO period ID");
+
+	if (!options.yes) {
+		throw new CliError(
+			"Refusing to delete without confirmation.",
+			"validation_error",
+			ExitCode.VALIDATION,
+			false,
+			"Pass --yes to confirm the deletion.",
+		);
+	}
+
+	let path = `/v2/ooo/${numericId}`;
+	if (options.user !== undefined) {
+		path += `?user_id=${validateSlackId(options.user, "user ID")}`;
+	}
+
+	const client = await createAuthenticatedClient(globalOpts);
+	await client.delete(path, idempotencyHeader());
+	const receipt = buildReceipt("deleted", null);
+	writeOutput(success({ id: numericId }, receipt));
+}

--- a/src/schemas/v2-ooo.ts
+++ b/src/schemas/v2-ooo.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { v2ItemEnvelope, v2ListEnvelope } from "./v2-common.ts";
+
+export const V2OooPeriodSchema = z.object({
+	id: z.number(),
+	user_id: z.string(),
+	start_date: z.string(),
+	end_date: z.string(),
+	days: z.number(),
+	timezone: z.string().nullable(),
+	created_at: z.string().nullable(),
+});
+
+export type V2OooPeriod = z.output<typeof V2OooPeriodSchema>;
+
+export const V2OooListResponseSchema = v2ListEnvelope(V2OooPeriodSchema);
+export const V2OooItemResponseSchema = v2ItemEnvelope(V2OooPeriodSchema);

--- a/tests/cli/commands/ooo.test.ts
+++ b/tests/cli/commands/ooo.test.ts
@@ -1,0 +1,305 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Command } from "commander";
+
+const mockHandleError = mock();
+const mockHandlers = {
+	handleOooList: mock(() => Promise.resolve()),
+	handleOooGet: mock(() => Promise.resolve()),
+	handleOooCreate: mock(() => Promise.resolve()),
+	handleOooEdit: mock(() => Promise.resolve()),
+	handleOooDelete: mock(() => Promise.resolve()),
+};
+mock.module("../../../src/handlers/ooo-handlers.ts", () => mockHandlers);
+mock.module("../../../src/errors/error-handler.ts", () => ({
+	handleError: mockHandleError,
+}));
+
+import { createOooCommand } from "../../../src/cli/commands/ooo.ts";
+import { addGlobalOptions } from "../../../src/cli/globals.ts";
+
+afterAll(() => {
+	mock.restore();
+});
+
+describe("createOooCommand", () => {
+	beforeEach(() => {
+		for (const fn of Object.values(mockHandlers)) fn.mockClear();
+		mockHandleError.mockClear();
+	});
+
+	test("returns a Command named 'ooo'", () => {
+		const cmd = createOooCommand();
+		expect(cmd.name()).toBe("ooo");
+	});
+
+	test("registers 5 subcommands", () => {
+		const cmd = createOooCommand();
+		expect(cmd.commands.length).toBe(5);
+	});
+
+	test("registers 'list' subcommand", () => {
+		const cmd = createOooCommand();
+		expect(cmd.commands.find((c) => c.name() === "list")).toBeDefined();
+	});
+
+	test("registers 'get' subcommand", () => {
+		const cmd = createOooCommand();
+		expect(cmd.commands.find((c) => c.name() === "get")).toBeDefined();
+	});
+
+	test("registers 'create' subcommand", () => {
+		const cmd = createOooCommand();
+		expect(cmd.commands.find((c) => c.name() === "create")).toBeDefined();
+	});
+
+	test("registers 'edit' subcommand", () => {
+		const cmd = createOooCommand();
+		expect(cmd.commands.find((c) => c.name() === "edit")).toBeDefined();
+	});
+
+	test("registers 'delete' subcommand", () => {
+		const cmd = createOooCommand();
+		expect(cmd.commands.find((c) => c.name() === "delete")).toBeDefined();
+	});
+
+	test("list subcommand calls handleOooList", async () => {
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(["ooo", "list", "--api-key", "test"], {
+			from: "user",
+		});
+		expect(mockHandlers.handleOooList).toHaveBeenCalled();
+	});
+
+	test("list subcommand passes mapped options to handler", async () => {
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(
+			[
+				"ooo",
+				"list",
+				"--user",
+				"U08LXSA31BJ",
+				"--cursor",
+				"opaque",
+				"--page-size",
+				"50",
+				"--api-key",
+				"test",
+			],
+			{ from: "user" },
+		);
+		expect(mockHandlers.handleOooList).toHaveBeenCalledWith(
+			expect.objectContaining({
+				user: "U08LXSA31BJ",
+				cursor: "opaque",
+				pageSize: "50",
+			}),
+			expect.anything(),
+		);
+	});
+
+	test("get subcommand calls handleOooGet with id and options", async () => {
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(["ooo", "get", "12", "--user", "U123", "--api-key", "test"], {
+			from: "user",
+		});
+		expect(mockHandlers.handleOooGet).toHaveBeenCalledWith(
+			"12",
+			expect.objectContaining({ user: "U123" }),
+			expect.anything(),
+		);
+	});
+
+	test("create subcommand calls handleOooCreate with mapped options", async () => {
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(
+			[
+				"ooo",
+				"create",
+				"--start-date",
+				"2026-08-01",
+				"--end-date",
+				"2026-08-15",
+				"--user",
+				"U123",
+				"--api-key",
+				"test",
+			],
+			{ from: "user" },
+		);
+		expect(mockHandlers.handleOooCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				startDate: "2026-08-01",
+				endDate: "2026-08-15",
+				user: "U123",
+			}),
+			expect.anything(),
+		);
+	});
+
+	test("create subcommand fails without --start-date", async () => {
+		const program = new Command();
+		addGlobalOptions(program);
+		const oooCmd = createOooCommand();
+		program.addCommand(oooCmd);
+		// Apply exitOverride to all commands in the tree so Commander
+		// throws instead of calling process.exit
+		program.exitOverride();
+		program.configureOutput({ writeErr: () => {}, writeOut: () => {} });
+		for (const sub of oooCmd.commands) {
+			sub.exitOverride();
+			sub.configureOutput({ writeErr: () => {}, writeOut: () => {} });
+		}
+		let thrownError: unknown;
+		try {
+			await program.parseAsync(["ooo", "create", "--end-date", "2026-08-15", "--api-key", "test"], {
+				from: "user",
+			});
+		} catch (err) {
+			thrownError = err;
+		}
+		expect(thrownError).toBeDefined();
+		expect((thrownError as Error).message).toContain("start-date");
+	});
+
+	test("create subcommand fails without --end-date", async () => {
+		const program = new Command();
+		addGlobalOptions(program);
+		const oooCmd = createOooCommand();
+		program.addCommand(oooCmd);
+		program.exitOverride();
+		program.configureOutput({ writeErr: () => {}, writeOut: () => {} });
+		for (const sub of oooCmd.commands) {
+			sub.exitOverride();
+			sub.configureOutput({ writeErr: () => {}, writeOut: () => {} });
+		}
+		let thrownError: unknown;
+		try {
+			await program.parseAsync(
+				["ooo", "create", "--start-date", "2026-08-01", "--api-key", "test"],
+				{ from: "user" },
+			);
+		} catch (err) {
+			thrownError = err;
+		}
+		expect(thrownError).toBeDefined();
+		expect((thrownError as Error).message).toContain("end-date");
+	});
+
+	test("edit subcommand calls handleOooEdit with id and mapped options", async () => {
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(
+			["ooo", "edit", "12", "--end-date", "2026-08-20", "--api-key", "test"],
+			{ from: "user" },
+		);
+		expect(mockHandlers.handleOooEdit).toHaveBeenCalledWith(
+			"12",
+			expect.objectContaining({ endDate: "2026-08-20" }),
+			expect.anything(),
+		);
+	});
+
+	test("delete subcommand calls handleOooDelete with id and options", async () => {
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(
+			["ooo", "delete", "12", "--user", "U123", "--yes", "--api-key", "test"],
+			{ from: "user" },
+		);
+		expect(mockHandlers.handleOooDelete).toHaveBeenCalledWith(
+			"12",
+			expect.objectContaining({ user: "U123", yes: true }),
+			expect.anything(),
+		);
+	});
+
+	test("delete subcommand passes yes=undefined when --yes omitted (handler refuses)", async () => {
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(["ooo", "delete", "12", "--api-key", "test"], {
+			from: "user",
+		});
+		const callArgs = mockHandlers.handleOooDelete.mock.calls[0] as unknown as [
+			string,
+			Record<string, unknown>,
+		];
+		expect(callArgs[1].yes).toBeUndefined();
+	});
+
+	test("list error is caught and passed to handleError", async () => {
+		mockHandlers.handleOooList.mockRejectedValueOnce(new Error("list error"));
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(["ooo", "list", "--api-key", "test"], {
+			from: "user",
+		});
+		expect(mockHandleError).toHaveBeenCalled();
+	});
+
+	test("get error is caught and passed to handleError", async () => {
+		mockHandlers.handleOooGet.mockRejectedValueOnce(new Error("get error"));
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(["ooo", "get", "12", "--api-key", "test"], {
+			from: "user",
+		});
+		expect(mockHandleError).toHaveBeenCalled();
+	});
+
+	test("create error is caught and passed to handleError", async () => {
+		mockHandlers.handleOooCreate.mockRejectedValueOnce(new Error("create error"));
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(
+			[
+				"ooo",
+				"create",
+				"--start-date",
+				"2026-08-01",
+				"--end-date",
+				"2026-08-15",
+				"--api-key",
+				"test",
+			],
+			{ from: "user" },
+		);
+		expect(mockHandleError).toHaveBeenCalled();
+	});
+
+	test("edit error is caught and passed to handleError", async () => {
+		mockHandlers.handleOooEdit.mockRejectedValueOnce(new Error("edit error"));
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(
+			["ooo", "edit", "12", "--end-date", "2026-08-20", "--api-key", "test"],
+			{ from: "user" },
+		);
+		expect(mockHandleError).toHaveBeenCalled();
+	});
+
+	test("delete error is caught and passed to handleError", async () => {
+		mockHandlers.handleOooDelete.mockRejectedValueOnce(new Error("delete error"));
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(["ooo", "delete", "12", "--api-key", "test"], {
+			from: "user",
+		});
+		expect(mockHandleError).toHaveBeenCalled();
+	});
+});

--- a/tests/cli/commands/ooo.test.ts
+++ b/tests/cli/commands/ooo.test.ts
@@ -86,7 +86,10 @@ describe("createOooCommand", () => {
 				"opaque",
 				"--page-size",
 				"50",
-				"--include-past",
+				"--after",
+				"2026-01-01",
+				"--before",
+				"2026-07-01",
 				"--api-key",
 				"test",
 			],
@@ -97,24 +100,21 @@ describe("createOooCommand", () => {
 				user: "U08LXSA31BJ",
 				cursor: "opaque",
 				pageSize: "50",
-				includePast: true,
+				after: "2026-01-01",
+				before: "2026-07-01",
 			}),
 			expect.anything(),
 		);
 	});
 
-	test("get subcommand calls handleOooGet with id and options", async () => {
+	test("get subcommand calls handleOooGet with the id", async () => {
 		const program = new Command();
 		addGlobalOptions(program);
 		program.addCommand(createOooCommand());
-		await program.parseAsync(["ooo", "get", "12", "--user", "U123", "--api-key", "test"], {
+		await program.parseAsync(["ooo", "get", "12", "--api-key", "test"], {
 			from: "user",
 		});
-		expect(mockHandlers.handleOooGet).toHaveBeenCalledWith(
-			"12",
-			expect.objectContaining({ user: "U123" }),
-			expect.anything(),
-		);
+		expect(mockHandlers.handleOooGet).toHaveBeenCalledWith("12", expect.anything());
 	});
 
 	test("create subcommand calls handleOooCreate with mapped options", async () => {
@@ -214,13 +214,12 @@ describe("createOooCommand", () => {
 		const program = new Command();
 		addGlobalOptions(program);
 		program.addCommand(createOooCommand());
-		await program.parseAsync(
-			["ooo", "delete", "12", "--user", "U123", "--yes", "--api-key", "test"],
-			{ from: "user" },
-		);
+		await program.parseAsync(["ooo", "delete", "12", "--yes", "--api-key", "test"], {
+			from: "user",
+		});
 		expect(mockHandlers.handleOooDelete).toHaveBeenCalledWith(
 			"12",
-			expect.objectContaining({ user: "U123", yes: true }),
+			expect.objectContaining({ yes: true }),
 			expect.anything(),
 		);
 	});

--- a/tests/cli/commands/ooo.test.ts
+++ b/tests/cli/commands/ooo.test.ts
@@ -86,6 +86,7 @@ describe("createOooCommand", () => {
 				"opaque",
 				"--page-size",
 				"50",
+				"--include-past",
 				"--api-key",
 				"test",
 			],
@@ -96,6 +97,7 @@ describe("createOooCommand", () => {
 				user: "U08LXSA31BJ",
 				cursor: "opaque",
 				pageSize: "50",
+				includePast: true,
 			}),
 			expect.anything(),
 		);

--- a/tests/cli/index.test.ts
+++ b/tests/cli/index.test.ts
@@ -10,7 +10,7 @@ import { APP_NAME, APP_VERSION } from "../../src/utils/constants.ts";
  * global options, exitOverride, and configureOutput.
  */
 
-const EXPECTED_COMMANDS = ["standup", "report", "poll", "auth", "me", "team"];
+const EXPECTED_COMMANDS = ["standup", "report", "poll", "ooo", "auth", "me", "team"];
 
 describe("CLI program registration", () => {
 	test("program is named with APP_NAME and has APP_VERSION set", () => {

--- a/tests/handlers/ooo-handlers.test.ts
+++ b/tests/handlers/ooo-handlers.test.ts
@@ -88,6 +88,15 @@ describe("handleOooList", () => {
 		});
 	});
 
+	test("maps --include-past to include_past=true and omits it by default", async () => {
+		await handleOooList({ includePast: true }, defaultGlobalOpts);
+		expect(mockGet).toHaveBeenCalledWith("/v2/ooo", { include_past: "true" });
+
+		mockGet.mockClear();
+		await handleOooList({ includePast: false }, defaultGlobalOpts);
+		expect(mockGet).toHaveBeenCalledWith("/v2/ooo", undefined);
+	});
+
 	test("rejects invalid --user value", async () => {
 		await expect(handleOooList({ user: "not-a-slack-id" }, defaultGlobalOpts)).rejects.toThrow(
 			/Invalid user ID/,

--- a/tests/handlers/ooo-handlers.test.ts
+++ b/tests/handlers/ooo-handlers.test.ts
@@ -1,0 +1,285 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// --- Mocks ---
+
+const mockGet = mock(() => Promise.resolve({ data: [], next_cursor: null, has_more: false }));
+const mockPost = mock(() => Promise.resolve({ data: {} }));
+const mockPatch = mock(() => Promise.resolve({ data: {} }));
+const mockDelete = mock(() => Promise.resolve(null));
+const mockCreateHttpClient = mock(() => ({
+	get: mockGet,
+	post: mockPost,
+	patch: mockPatch,
+	put: mock(),
+	delete: mockDelete,
+}));
+
+mock.module("../../src/http/client.ts", () => ({
+	createHttpClient: mockCreateHttpClient,
+}));
+
+mock.module("../../src/auth/resolver.ts", () => ({
+	resolveCredential: mock(() => Promise.resolve({ apiKey: "test-key", source: "env" })),
+}));
+
+const mockWriteOutput = mock(() => {});
+mock.module("../../src/output/formatter.ts", () => ({
+	writeOutput: mockWriteOutput,
+}));
+
+import type { GlobalOptions } from "../../src/cli/globals.ts";
+import {
+	handleOooCreate,
+	handleOooDelete,
+	handleOooEdit,
+	handleOooGet,
+	handleOooList,
+} from "../../src/handlers/ooo-handlers.ts";
+
+const defaultGlobalOpts: GlobalOptions = {
+	apiKey: undefined,
+};
+
+const sampleOooPeriod = {
+	id: 12,
+	user_id: "U08LXSA31BJ",
+	start_date: "2026-08-01",
+	end_date: "2026-08-15",
+	days: 15,
+	timezone: "Europe/Athens",
+	created_at: "2026-07-12T10:00:00+00:00",
+};
+
+afterAll(() => {
+	mock.restore();
+});
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function resetMocks() {
+	mockGet.mockClear();
+	mockPost.mockClear();
+	mockPatch.mockClear();
+	mockDelete.mockClear();
+	mockCreateHttpClient.mockClear();
+	mockWriteOutput.mockClear();
+	mockGet.mockImplementation(() =>
+		Promise.resolve({ data: [sampleOooPeriod], next_cursor: null, has_more: false }),
+	);
+	mockPost.mockImplementation(() => Promise.resolve({ data: sampleOooPeriod }));
+	mockPatch.mockImplementation(() => Promise.resolve({ data: sampleOooPeriod }));
+	mockDelete.mockImplementation(() => Promise.resolve(null));
+}
+
+describe("handleOooList", () => {
+	beforeEach(resetMocks);
+
+	test("calls GET /v2/ooo without params when no filters", async () => {
+		await handleOooList({}, defaultGlobalOpts);
+		expect(mockGet).toHaveBeenCalledWith("/v2/ooo", undefined);
+	});
+
+	test("maps --user, --cursor, --page-size to user_id, cursor, limit", async () => {
+		await handleOooList({ user: "U08LXSA31BJ", cursor: "tok", pageSize: "50" }, defaultGlobalOpts);
+		expect(mockGet).toHaveBeenCalledWith("/v2/ooo", {
+			user_id: "U08LXSA31BJ",
+			cursor: "tok",
+			limit: "50",
+		});
+	});
+
+	test("rejects invalid --user value", async () => {
+		await expect(handleOooList({ user: "not-a-slack-id" }, defaultGlobalOpts)).rejects.toThrow(
+			/Invalid user ID/,
+		);
+		expect(mockGet).not.toHaveBeenCalled();
+	});
+
+	test("rejects invalid --page-size value", async () => {
+		await expect(handleOooList({ pageSize: "0" }, defaultGlobalOpts)).rejects.toThrow(
+			/Invalid limit/,
+		);
+		expect(mockGet).not.toHaveBeenCalled();
+	});
+
+	test("surfaces next_cursor and has_more in writeOutput metadata", async () => {
+		mockGet.mockImplementation(() =>
+			Promise.resolve({ data: [sampleOooPeriod], next_cursor: "next-token", has_more: true }),
+		);
+		await handleOooList({}, defaultGlobalOpts);
+		const envelope = mockWriteOutput.mock.calls[0]?.[0] as {
+			data: Array<{ id: number }>;
+			metadata: Record<string, unknown>;
+		};
+		expect(envelope.data[0]?.id).toBe(12);
+		expect(envelope.metadata.next_cursor).toBe("next-token");
+		expect(envelope.metadata.has_more).toBe(true);
+	});
+});
+
+describe("handleOooGet", () => {
+	beforeEach(resetMocks);
+
+	test("GET /v2/ooo/{id} with no params by default", async () => {
+		mockGet.mockImplementation(() => Promise.resolve({ data: sampleOooPeriod }));
+		await handleOooGet("12", {}, defaultGlobalOpts);
+		expect(mockGet).toHaveBeenCalledWith("/v2/ooo/12", undefined);
+		const envelope = mockWriteOutput.mock.calls[0]?.[0] as { ok: boolean; data: { id: number } };
+		expect(envelope.ok).toBe(true);
+		expect(envelope.data.id).toBe(12);
+	});
+
+	test("passes --user through as user_id query param", async () => {
+		mockGet.mockImplementation(() => Promise.resolve({ data: sampleOooPeriod }));
+		await handleOooGet("12", { user: "U08LXSA31BJ" }, defaultGlobalOpts);
+		expect(mockGet).toHaveBeenCalledWith("/v2/ooo/12", { user_id: "U08LXSA31BJ" });
+	});
+
+	test("rejects non-numeric id", async () => {
+		await expect(handleOooGet("abc", {}, defaultGlobalOpts)).rejects.toThrow(
+			/Invalid OOO period ID/,
+		);
+		expect(mockGet).not.toHaveBeenCalled();
+	});
+});
+
+describe("handleOooCreate", () => {
+	beforeEach(resetMocks);
+
+	test("POST /v2/ooo with snake_case dates and Idempotency-Key header", async () => {
+		await handleOooCreate({ startDate: "2026-08-01", endDate: "2026-08-15" }, defaultGlobalOpts);
+		const call = mockPost.mock.calls[0] as [string, unknown, Record<string, string>];
+		expect(call[0]).toBe("/v2/ooo");
+		expect(call[1]).toEqual({ start_date: "2026-08-01", end_date: "2026-08-15" });
+		expect(call[2]["Idempotency-Key"]).toMatch(UUID_RE);
+	});
+
+	test("includes user_id in body when --user given", async () => {
+		await handleOooCreate(
+			{ startDate: "2026-08-01", endDate: "2026-08-15", user: "U08LXSA31BJ" },
+			defaultGlobalOpts,
+		);
+		const [, body] = mockPost.mock.calls[0] as [string, Record<string, unknown>];
+		expect(body.user_id).toBe("U08LXSA31BJ");
+	});
+
+	test("returns receipt with operation=created and undo delete command", async () => {
+		await handleOooCreate({ startDate: "2026-08-01", endDate: "2026-08-15" }, defaultGlobalOpts);
+		const envelope = mockWriteOutput.mock.calls[0]?.[0] as {
+			metadata: { operation: string; undo: string | null };
+		};
+		expect(envelope.metadata.operation).toBe("created");
+		expect(envelope.metadata.undo).toBe("geekbot ooo delete 12 --yes");
+	});
+
+	test("undo command includes --user when creating for another member", async () => {
+		await handleOooCreate(
+			{ startDate: "2026-08-01", endDate: "2026-08-15", user: "U08LXSA31BJ" },
+			defaultGlobalOpts,
+		);
+		const envelope = mockWriteOutput.mock.calls[0]?.[0] as {
+			metadata: { undo: string | null };
+		};
+		expect(envelope.metadata.undo).toBe("geekbot ooo delete 12 --user U08LXSA31BJ --yes");
+	});
+
+	test("rejects non-YYYY-MM-DD start date", async () => {
+		await expect(
+			handleOooCreate({ startDate: "01/08/2026", endDate: "2026-08-15" }, defaultGlobalOpts),
+		).rejects.toThrow(/Invalid date for --start-date/);
+		expect(mockPost).not.toHaveBeenCalled();
+	});
+
+	test("rejects impossible calendar date", async () => {
+		await expect(
+			handleOooCreate({ startDate: "2026-02-31", endDate: "2026-03-05" }, defaultGlobalOpts),
+		).rejects.toThrow(/not a valid calendar date/);
+		expect(mockPost).not.toHaveBeenCalled();
+	});
+});
+
+describe("handleOooEdit", () => {
+	beforeEach(resetMocks);
+
+	test("PATCH /v2/ooo/{id} with both dates and Idempotency-Key header", async () => {
+		await handleOooEdit(
+			"12",
+			{ startDate: "2026-08-03", endDate: "2026-08-20" },
+			defaultGlobalOpts,
+		);
+		const call = mockPatch.mock.calls[0] as [string, unknown, Record<string, string>];
+		expect(call[0]).toBe("/v2/ooo/12");
+		expect(call[1]).toEqual({ start_date: "2026-08-03", end_date: "2026-08-20" });
+		expect(call[2]["Idempotency-Key"]).toMatch(UUID_RE);
+	});
+
+	test("sends only end_date when --start-date omitted", async () => {
+		await handleOooEdit("12", { endDate: "2026-08-20" }, defaultGlobalOpts);
+		const [, body] = mockPatch.mock.calls[0] as [string, Record<string, unknown>];
+		expect(body).toEqual({ end_date: "2026-08-20" });
+	});
+
+	test("includes user_id in body when --user given", async () => {
+		await handleOooEdit("12", { endDate: "2026-08-20", user: "U08LXSA31BJ" }, defaultGlobalOpts);
+		const [, body] = mockPatch.mock.calls[0] as [string, Record<string, unknown>];
+		expect(body).toEqual({ end_date: "2026-08-20", user_id: "U08LXSA31BJ" });
+	});
+
+	test("rejects edit with neither --start-date nor --end-date", async () => {
+		await expect(handleOooEdit("12", {}, defaultGlobalOpts)).rejects.toThrow(
+			/At least one of --start-date or --end-date is required/,
+		);
+		expect(mockPatch).not.toHaveBeenCalled();
+	});
+
+	test("returns receipt with operation=updated and undo=null", async () => {
+		await handleOooEdit("12", { endDate: "2026-08-20" }, defaultGlobalOpts);
+		const envelope = mockWriteOutput.mock.calls[0]?.[0] as {
+			metadata: { operation: string; undo: string | null };
+		};
+		expect(envelope.metadata.operation).toBe("updated");
+		expect(envelope.metadata.undo).toBeNull();
+	});
+});
+
+describe("handleOooDelete", () => {
+	beforeEach(resetMocks);
+
+	test("DELETE /v2/ooo/{id} with Idempotency-Key header when --yes given", async () => {
+		await handleOooDelete("12", { yes: true }, defaultGlobalOpts);
+		const call = mockDelete.mock.calls[0] as [string, Record<string, string>];
+		expect(call[0]).toBe("/v2/ooo/12");
+		expect(call[1]["Idempotency-Key"]).toMatch(UUID_RE);
+	});
+
+	test("appends user_id query param when --user given", async () => {
+		await handleOooDelete("12", { user: "U08LXSA31BJ", yes: true }, defaultGlobalOpts);
+		const call = mockDelete.mock.calls[0] as [string, Record<string, string>];
+		expect(call[0]).toBe("/v2/ooo/12?user_id=U08LXSA31BJ");
+	});
+
+	test("refuses to delete without --yes", async () => {
+		await expect(handleOooDelete("12", {}, defaultGlobalOpts)).rejects.toThrow(
+			/Refusing to delete without confirmation/,
+		);
+		expect(mockDelete).not.toHaveBeenCalled();
+	});
+
+	test("returns receipt with operation=deleted and the deleted id", async () => {
+		await handleOooDelete("12", { yes: true }, defaultGlobalOpts);
+		const envelope = mockWriteOutput.mock.calls[0]?.[0] as {
+			data: { id: number };
+			metadata: { operation: string; undo: string | null };
+		};
+		expect(envelope.data.id).toBe(12);
+		expect(envelope.metadata.operation).toBe("deleted");
+		expect(envelope.metadata.undo).toBeNull();
+	});
+
+	test("rejects non-numeric id", async () => {
+		await expect(handleOooDelete("abc", {}, defaultGlobalOpts)).rejects.toThrow(
+			/Invalid OOO period ID/,
+		);
+		expect(mockDelete).not.toHaveBeenCalled();
+	});
+});

--- a/tests/handlers/ooo-handlers.test.ts
+++ b/tests/handlers/ooo-handlers.test.ts
@@ -88,13 +88,26 @@ describe("handleOooList", () => {
 		});
 	});
 
-	test("maps --include-past to include_past=true and omits it by default", async () => {
-		await handleOooList({ includePast: true }, defaultGlobalOpts);
-		expect(mockGet).toHaveBeenCalledWith("/v2/ooo", { include_past: "true" });
+	test("maps --after/--before to since/until and omits them by default", async () => {
+		await handleOooList({ after: "2026-01-01", before: "2026-07-01" }, defaultGlobalOpts);
+		expect(mockGet).toHaveBeenCalledWith("/v2/ooo", {
+			since: "2026-01-01",
+			until: "2026-07-01",
+		});
 
 		mockGet.mockClear();
-		await handleOooList({ includePast: false }, defaultGlobalOpts);
+		await handleOooList({}, defaultGlobalOpts);
 		expect(mockGet).toHaveBeenCalledWith("/v2/ooo", undefined);
+	});
+
+	test("rejects invalid --after/--before dates before any request", async () => {
+		await expect(handleOooList({ after: "not-a-date" }, defaultGlobalOpts)).rejects.toThrow(
+			/Invalid date for --after/,
+		);
+		await expect(handleOooList({ before: "2026-02-31" }, defaultGlobalOpts)).rejects.toThrow(
+			/Invalid date for --before/,
+		);
+		expect(mockGet).not.toHaveBeenCalled();
 	});
 
 	test("rejects invalid --user value", async () => {
@@ -129,25 +142,17 @@ describe("handleOooList", () => {
 describe("handleOooGet", () => {
 	beforeEach(resetMocks);
 
-	test("GET /v2/ooo/{id} with no params by default", async () => {
+	test("GET /v2/ooo/{id} by id, no query params", async () => {
 		mockGet.mockImplementation(() => Promise.resolve({ data: sampleOooPeriod }));
-		await handleOooGet("12", {}, defaultGlobalOpts);
-		expect(mockGet).toHaveBeenCalledWith("/v2/ooo/12", undefined);
+		await handleOooGet("12", defaultGlobalOpts);
+		expect(mockGet).toHaveBeenCalledWith("/v2/ooo/12");
 		const envelope = mockWriteOutput.mock.calls[0]?.[0] as { ok: boolean; data: { id: number } };
 		expect(envelope.ok).toBe(true);
 		expect(envelope.data.id).toBe(12);
 	});
 
-	test("passes --user through as user_id query param", async () => {
-		mockGet.mockImplementation(() => Promise.resolve({ data: sampleOooPeriod }));
-		await handleOooGet("12", { user: "U08LXSA31BJ" }, defaultGlobalOpts);
-		expect(mockGet).toHaveBeenCalledWith("/v2/ooo/12", { user_id: "U08LXSA31BJ" });
-	});
-
 	test("rejects non-numeric id", async () => {
-		await expect(handleOooGet("abc", {}, defaultGlobalOpts)).rejects.toThrow(
-			/Invalid OOO period ID/,
-		);
+		await expect(handleOooGet("abc", defaultGlobalOpts)).rejects.toThrow(/Invalid OOO period ID/);
 		expect(mockGet).not.toHaveBeenCalled();
 	});
 });
@@ -181,7 +186,7 @@ describe("handleOooCreate", () => {
 		expect(envelope.metadata.undo).toBe("geekbot ooo delete 12 --yes");
 	});
 
-	test("undo command includes --user when creating for another member", async () => {
+	test("undo command is by-id even when creating for another member", async () => {
 		await handleOooCreate(
 			{ startDate: "2026-08-01", endDate: "2026-08-15", user: "U08LXSA31BJ" },
 			defaultGlobalOpts,
@@ -189,7 +194,7 @@ describe("handleOooCreate", () => {
 		const envelope = mockWriteOutput.mock.calls[0]?.[0] as {
 			metadata: { undo: string | null };
 		};
-		expect(envelope.metadata.undo).toBe("geekbot ooo delete 12 --user U08LXSA31BJ --yes");
+		expect(envelope.metadata.undo).toBe("geekbot ooo delete 12 --yes");
 	});
 
 	test("rejects non-YYYY-MM-DD start date", async () => {
@@ -228,12 +233,6 @@ describe("handleOooEdit", () => {
 		expect(body).toEqual({ end_date: "2026-08-20" });
 	});
 
-	test("includes user_id in body when --user given", async () => {
-		await handleOooEdit("12", { endDate: "2026-08-20", user: "U08LXSA31BJ" }, defaultGlobalOpts);
-		const [, body] = mockPatch.mock.calls[0] as [string, Record<string, unknown>];
-		expect(body).toEqual({ end_date: "2026-08-20", user_id: "U08LXSA31BJ" });
-	});
-
 	test("rejects edit with neither --start-date nor --end-date", async () => {
 		await expect(handleOooEdit("12", {}, defaultGlobalOpts)).rejects.toThrow(
 			/At least one of --start-date or --end-date is required/,
@@ -259,12 +258,6 @@ describe("handleOooDelete", () => {
 		const call = mockDelete.mock.calls[0] as [string, Record<string, string>];
 		expect(call[0]).toBe("/v2/ooo/12");
 		expect(call[1]["Idempotency-Key"]).toMatch(UUID_RE);
-	});
-
-	test("appends user_id query param when --user given", async () => {
-		await handleOooDelete("12", { user: "U08LXSA31BJ", yes: true }, defaultGlobalOpts);
-		const call = mockDelete.mock.calls[0] as [string, Record<string, string>];
-		expect(call[0]).toBe("/v2/ooo/12?user_id=U08LXSA31BJ");
 	});
 
 	test("refuses to delete without --yes", async () => {

--- a/tests/schemas/v2-ooo.test.ts
+++ b/tests/schemas/v2-ooo.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import {
+	V2OooItemResponseSchema,
+	V2OooListResponseSchema,
+	V2OooPeriodSchema,
+} from "../../src/schemas/v2-ooo.ts";
+
+const VALID_PERIOD = {
+	id: 12,
+	user_id: "U08LXSA31BJ",
+	start_date: "2026-08-01",
+	end_date: "2026-08-15",
+	days: 15,
+	timezone: "Europe/Athens",
+	created_at: "2026-07-12T10:00:00+00:00",
+};
+
+describe("V2OooPeriodSchema", () => {
+	test("parses a valid OOO period", () => {
+		const parsed = V2OooPeriodSchema.parse(VALID_PERIOD);
+		expect(parsed.id).toBe(12);
+		expect(parsed.user_id).toBe("U08LXSA31BJ");
+		expect(parsed.start_date).toBe("2026-08-01");
+		expect(parsed.end_date).toBe("2026-08-15");
+		expect(parsed.days).toBe(15);
+	});
+
+	test("parses null timezone and created_at", () => {
+		const parsed = V2OooPeriodSchema.parse({
+			...VALID_PERIOD,
+			timezone: null,
+			created_at: null,
+		});
+		expect(parsed.timezone).toBeNull();
+		expect(parsed.created_at).toBeNull();
+	});
+
+	test("rejects string id", () => {
+		expect(() => V2OooPeriodSchema.parse({ ...VALID_PERIOD, id: "12" })).toThrow();
+	});
+
+	test("rejects missing user_id", () => {
+		const { user_id: _userId, ...rest } = VALID_PERIOD;
+		expect(() => V2OooPeriodSchema.parse(rest)).toThrow();
+	});
+
+	test("rejects non-numeric days", () => {
+		expect(() => V2OooPeriodSchema.parse({ ...VALID_PERIOD, days: "15" })).toThrow();
+	});
+});
+
+describe("V2OooListResponseSchema", () => {
+	test("parses a list envelope with periods", () => {
+		const parsed = V2OooListResponseSchema.parse({
+			data: [VALID_PERIOD],
+			next_cursor: "tok",
+			has_more: true,
+		});
+		expect(parsed.data.length).toBe(1);
+		expect(parsed.next_cursor).toBe("tok");
+		expect(parsed.has_more).toBe(true);
+	});
+
+	test("parses null next_cursor", () => {
+		const parsed = V2OooListResponseSchema.parse({
+			data: [],
+			next_cursor: null,
+			has_more: false,
+		});
+		expect(parsed.next_cursor).toBeNull();
+	});
+
+	test("rejects envelope missing has_more", () => {
+		expect(() => V2OooListResponseSchema.parse({ data: [], next_cursor: null })).toThrow();
+	});
+});
+
+describe("V2OooItemResponseSchema", () => {
+	test("parses an item envelope", () => {
+		const parsed = V2OooItemResponseSchema.parse({ data: VALID_PERIOD });
+		expect(parsed.data.id).toBe(12);
+	});
+
+	test("rejects a bare period without envelope", () => {
+		expect(() => V2OooItemResponseSchema.parse(VALID_PERIOD)).toThrow();
+	});
+});


### PR DESCRIPTION
## What

Adds a `geekbot ooo` command group wrapping the v2 out-of-office API — `list`, `get`, `create`, `edit`, `delete` — with cursor pagination, an `--after`/`--before` date window on `list`, idempotency keys on writes, and undo receipts.

## v2 API contract alignment

## Testing

- Full OOO test suite green; lint (`biome`) + `tsc --noEmit` clean; coverage 95.62% (> 95% gate).
- Exercised end-to-end against the local dev api (`gb-api-1`, v2 endpoints): list/get/create/edit/delete lifecycle verified, and `--user` correctly rejected on get/edit/delete.

## Versioning (per RELEASING.md)

This branch touches both release lines, so both are bumped:

| Artifact | File(s) | Bump |
|---|---|---|
| npm CLI | `package.json` | 1.1.0 → **1.2.0** (new command group) |
| Agent plugin | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `plugins/geekbot/.codex-plugin/plugin.json` | 0.2.0 → **0.3.0** (ooo skill docs) |

### Release steps after merge
- **npm CLI**: cut a GitHub Release tagged `v1.2.0` on the **merge commit** → `publish.yml` runs `npm publish --provenance`.
- **Agent plugin**: no tag/publish — the merge to `main` *is* the release (clients pull `0.3.0` on next marketplace refresh).