### PR TITLE
ooo list: replace --user with --users/--standups filters (v2.0.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
 	},
 	"metadata": {
 		"description": "Geekbot CLI — standups, reports, polls from the terminal and AI agents",
-		"version": "0.3.0"
+		"version": "0.4.0"
 	},
 	"plugins": [
 		{

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "geekbot",
 	"description": "Manage Geekbot standups, reports, and polls from Claude via the geekbot CLI",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"author": { "name": "Geekbot" },
 	"homepage": "https://github.com/geekbot-com/geekbot-cli"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "geekbot-cli",
-	"version": "1.2.0",
+	"version": "2.0.0",
 	"description": "CLI tool for managing Geekbot standups, reports, and polls — designed for AI agents and humans",
 	"type": "module",
 	"license": "MIT",

--- a/plugins/geekbot/.codex-plugin/plugin.json
+++ b/plugins/geekbot/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "geekbot",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "Manage Geekbot standups, reports, and polls from Codex via the geekbot CLI",
 	"author": { "name": "Geekbot" },
 	"homepage": "https://github.com/geekbot-com/geekbot-cli",

--- a/skills/geekbot-run/cli-commands.md
+++ b/skills/geekbot-run/cli-commands.md
@@ -333,31 +333,37 @@ poll's current members — a sign it needs syncing.
 
 Out-of-office periods pause standup notifications for a user while they are
 away — the same periods a user sets by messaging `ooo` to the Geekbot bot.
-By default commands operate on the authenticated user; admins can manage
-another member's periods with `--user <id>` (Slack-style ID). All dates are
-`YYYY-MM-DD`; `end_date` is inclusive. Overlapping periods are allowed —
-each entry is independent.
+Write commands operate on the authenticated user; admins can create a
+period for another member with `ooo create --user <id>` (Slack-style ID).
+All dates are `YYYY-MM-DD`; `end_date` is inclusive. Overlapping periods
+are allowed — each entry is independent.
 
 ### ooo list
 
-List out-of-office periods via `GET /v2/ooo`. By default only current and
+List out-of-office periods via `GET /v2/ooo` for every member you can view
+(admins: the whole team; members: themselves and teammates sharing an
+active standup). `--users` / `--standups` narrow the result — one or the
+other, never both (combining them is rejected). By default only current and
 upcoming periods are returned; `--after`/`--before` bound the date window
 like `report list` (a period matches when it overlaps the window), so an
 `--after` in the past retrieves historical periods. Cursor-paginated,
 ordered by start date.
 
 ```bash
-geekbot ooo list                          # your own current + upcoming periods
+geekbot ooo list                          # every visible member's current + upcoming periods
+geekbot ooo list --users U08LXSA31BJ      # one member's
+geekbot ooo list --users U08LXSA31BJ,U08LXSA31BK   # several members'
+geekbot ooo list --standups 123           # members of a standup
 geekbot ooo list --after 2026-01-01       # history since Jan 1 (plus upcoming)
 geekbot ooo list --after 2026-01-01 --before 2026-07-01   # bounded window
-geekbot ooo list --user U08LXSA31BJ       # another member's
 geekbot ooo list --page-size 50           # larger page
 geekbot ooo list --cursor "<token>"       # next page
 ```
 
 | Flag | Default | Notes |
 |------|---------|-------|
-| `--user <id>` | you | Slack-style user ID; admins can list anyone, members can list teammates they share an active standup with |
+| `--users <ids>` | everyone visible | Comma-separated Slack-style user IDs; ids you cannot view are silently dropped. Cannot be combined with `--standups` |
+| `--standups <ids>` | — | Comma-separated standup IDs — restricts to members of these standups. Cannot be combined with `--users` |
 | `--after <date>` | now | Only periods ending on/after this date (v2 `since`, inclusive) — set a past date for history |
 | `--before <date>` | — | Only periods starting before this date (v2 `until`, exclusive) |
 | `--cursor <token>` | — | Opaque pagination cursor from a previous response |

--- a/src/cli/commands/ooo.ts
+++ b/src/cli/commands/ooo.ts
@@ -16,8 +16,17 @@ export function createOooCommand(): Command {
 
 	ooo
 		.command("list")
-		.description("List current and upcoming out-of-office periods (v2)")
-		.option("--user <id>", "Slack-style user ID (admins listing another member, e.g. U123)")
+		.description(
+			"List current and upcoming out-of-office periods for every member you can view (v2)",
+		)
+		.option(
+			"--users <ids>",
+			"Comma-separated Slack-style user IDs to restrict to (e.g. U123,U456; inaccessible ids are dropped; cannot be combined with --standups)",
+		)
+		.option(
+			"--standups <ids>",
+			"Comma-separated standup IDs — restrict to members of these standups (cannot be combined with --users)",
+		)
 		.option("--cursor <token>", "Opaque pagination cursor from a previous response")
 		.option("--page-size <n>", "Page size (1-100, default 25)")
 		.option(
@@ -30,7 +39,7 @@ export function createOooCommand(): Command {
 		)
 		.addHelpText(
 			"after",
-			'\nExamples:\n  geekbot ooo list\n  geekbot ooo list --user U08LXSA31BJ\n  geekbot ooo list --after 2026-01-01 --before 2026-07-01\n  geekbot ooo list --page-size 50\n  geekbot ooo list --cursor "<token>"',
+			'\nExamples:\n  geekbot ooo list\n  geekbot ooo list --users U08LXSA31BJ,U08LXSA31BK\n  geekbot ooo list --standups 123,456\n  geekbot ooo list --after 2026-01-01 --before 2026-07-01\n  geekbot ooo list --page-size 50\n  geekbot ooo list --cursor "<token>"',
 		)
 		.action(async function (this: Command) {
 			const globalOpts = getGlobalOptions(this);
@@ -38,7 +47,8 @@ export function createOooCommand(): Command {
 				const opts = this.opts();
 				await handleOooList(
 					{
-						user: opts.user,
+						users: opts.users,
+						standups: opts.standups,
 						cursor: opts.cursor,
 						pageSize: opts.pageSize,
 						after: opts.after,

--- a/src/handlers/ooo-handlers.ts
+++ b/src/handlers/ooo-handlers.ts
@@ -8,12 +8,19 @@ import { writeOutput } from "../output/formatter.ts";
 import { V2OooItemResponseSchema, V2OooListResponseSchema } from "../schemas/v2-ooo.ts";
 import { parseDateFilter, parseV2DateFilter } from "../utils/input-parsers.ts";
 import { buildReceipt } from "../utils/receipt.ts";
-import { validateLimit, validateNumericId, validateSlackId } from "../utils/validation.ts";
+import {
+	validateLimit,
+	validateNumericId,
+	validateNumericIdList,
+	validateSlackId,
+	validateSlackIdList,
+} from "../utils/validation.ts";
 
 // ── Option Interfaces ─────────────────────────────────────────────────
 
 export interface OooListOptions {
-	user?: string;
+	users?: string;
+	standups?: string;
 	cursor?: string;
 	pageSize?: string;
 	after?: string;
@@ -74,17 +81,33 @@ function buildParams(
 /**
  * Handle `geekbot ooo list` command.
  * Fetches out-of-office periods from GET /v2/ooo (cursor-paginated, single
- * page per call). Without a date window the API returns current and upcoming
- * periods; `--after`/`--before` map to v2 `since`/`until` like `report list`.
+ * page per call) for every member the caller can view. `--users`/`--standups`
+ * narrow the result (the API intersects them with the caller's view rights and
+ * silently drops inaccessible ids); they are mutually exclusive, mirroring the
+ * API. Without a date window the API returns current and upcoming periods;
+ * `--after`/`--before` map to v2 `since`/`until` like `report list`.
  */
 export async function handleOooList(
 	options: OooListOptions,
 	globalOpts: GlobalOptions,
 ): Promise<void> {
+	if (options.users && options.standups) {
+		throw new CliError(
+			"--users and --standups cannot be combined.",
+			"validation_error",
+			ExitCode.VALIDATION,
+			false,
+			"Provide one filter or the other, e.g.: geekbot ooo list --users U123 or geekbot ooo list --standups 42",
+		);
+	}
+
 	const client = await createAuthenticatedClient(globalOpts);
 
 	const params = buildParams({
-		user_id: options.user ? validateSlackId(options.user, "user ID") : undefined,
+		users: options.users ? validateSlackIdList(options.users, "user ID").join(",") : undefined,
+		standups: options.standups
+			? validateNumericIdList(options.standups, "standup ID").join(",")
+			: undefined,
 		cursor: options.cursor,
 		limit: options.pageSize ? String(validateLimit(options.pageSize)) : undefined,
 		since: options.after ? parseV2DateFilter(options.after, "--after") : undefined,

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -66,6 +66,18 @@ export function validateSlackIdList(value: string, label: string): string[] {
 }
 
 /**
+ * Validate a comma-separated list of numeric IDs (positive integers).
+ */
+export function validateNumericIdList(value: string, label: string): number[] {
+	const parts = value.split(",");
+	const result: number[] = [];
+	for (const part of parts) {
+		result.push(validateNumericId(part.trim(), label));
+	}
+	return result;
+}
+
+/**
  * Validate that a string is a valid non-negative integer (for wait_time etc.).
  */
 export function validateWaitTime(value: string): number {

--- a/tests/cli/commands/ooo.test.ts
+++ b/tests/cli/commands/ooo.test.ts
@@ -80,8 +80,8 @@ describe("createOooCommand", () => {
 			[
 				"ooo",
 				"list",
-				"--user",
-				"U08LXSA31BJ",
+				"--users",
+				"U08LXSA31BJ,U08LXSA31BK",
 				"--cursor",
 				"opaque",
 				"--page-size",
@@ -97,12 +97,25 @@ describe("createOooCommand", () => {
 		);
 		expect(mockHandlers.handleOooList).toHaveBeenCalledWith(
 			expect.objectContaining({
-				user: "U08LXSA31BJ",
+				users: "U08LXSA31BJ,U08LXSA31BK",
 				cursor: "opaque",
 				pageSize: "50",
 				after: "2026-01-01",
 				before: "2026-07-01",
 			}),
+			expect.anything(),
+		);
+	});
+
+	test("list subcommand passes --standups to handler", async () => {
+		const program = new Command();
+		addGlobalOptions(program);
+		program.addCommand(createOooCommand());
+		await program.parseAsync(["ooo", "list", "--standups", "12,34", "--api-key", "test"], {
+			from: "user",
+		});
+		expect(mockHandlers.handleOooList).toHaveBeenCalledWith(
+			expect.objectContaining({ standups: "12,34" }),
 			expect.anything(),
 		);
 	});

--- a/tests/handlers/ooo-handlers.test.ts
+++ b/tests/handlers/ooo-handlers.test.ts
@@ -79,13 +79,28 @@ describe("handleOooList", () => {
 		expect(mockGet).toHaveBeenCalledWith("/v2/ooo", undefined);
 	});
 
-	test("maps --user, --cursor, --page-size to user_id, cursor, limit", async () => {
-		await handleOooList({ user: "U08LXSA31BJ", cursor: "tok", pageSize: "50" }, defaultGlobalOpts);
+	test("maps --users, --cursor, --page-size to users, cursor, limit", async () => {
+		await handleOooList(
+			{ users: "U08LXSA31BJ, U08LXSA31BK", cursor: "tok", pageSize: "50" },
+			defaultGlobalOpts,
+		);
 		expect(mockGet).toHaveBeenCalledWith("/v2/ooo", {
-			user_id: "U08LXSA31BJ",
+			users: "U08LXSA31BJ,U08LXSA31BK",
 			cursor: "tok",
 			limit: "50",
 		});
+	});
+
+	test("maps --standups to standups", async () => {
+		await handleOooList({ standups: "12, 34" }, defaultGlobalOpts);
+		expect(mockGet).toHaveBeenCalledWith("/v2/ooo", { standups: "12,34" });
+	});
+
+	test("rejects --users combined with --standups before any request", async () => {
+		await expect(
+			handleOooList({ users: "U08LXSA31BJ", standups: "12" }, defaultGlobalOpts),
+		).rejects.toThrow(/--users and --standups cannot be combined/);
+		expect(mockGet).not.toHaveBeenCalled();
 	});
 
 	test("maps --after/--before to since/until and omits them by default", async () => {
@@ -110,9 +125,16 @@ describe("handleOooList", () => {
 		expect(mockGet).not.toHaveBeenCalled();
 	});
 
-	test("rejects invalid --user value", async () => {
-		await expect(handleOooList({ user: "not-a-slack-id" }, defaultGlobalOpts)).rejects.toThrow(
-			/Invalid user ID/,
+	test("rejects invalid --users value (any bad element)", async () => {
+		await expect(
+			handleOooList({ users: "U08LXSA31BJ,not-a-slack-id" }, defaultGlobalOpts),
+		).rejects.toThrow(/Invalid user ID/);
+		expect(mockGet).not.toHaveBeenCalled();
+	});
+
+	test("rejects invalid --standups value (any bad element)", async () => {
+		await expect(handleOooList({ standups: "12,abc" }, defaultGlobalOpts)).rejects.toThrow(
+			/Invalid standup ID/,
 		);
 		expect(mockGet).not.toHaveBeenCalled();
 	});

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -5,6 +5,7 @@ import {
 	validateDayAbbreviations,
 	validateLimit,
 	validateNumericId,
+	validateNumericIdList,
 	validateSlackId,
 	validateSlackIdList,
 	validateTimeFormat,
@@ -18,6 +19,7 @@ describe("validation module public API", () => {
 			"validateDayAbbreviations",
 			"validateLimit",
 			"validateNumericId",
+			"validateNumericIdList",
 			"validateSlackId",
 			"validateSlackIdList",
 			"validateTimeFormat",
@@ -137,6 +139,28 @@ describe("validateSlackIdList", () => {
 
 	test("throws CliError when any value is invalid", () => {
 		expect(() => validateSlackIdList("U123,bad,U456", "user ID")).toThrow(CliError);
+	});
+});
+
+describe("validateNumericIdList", () => {
+	test("returns number array for comma-separated numeric IDs", () => {
+		expect(validateNumericIdList("12,34", "standup ID")).toEqual([12, 34]);
+	});
+
+	test("returns single-element array for single ID", () => {
+		expect(validateNumericIdList("123", "standup ID")).toEqual([123]);
+	});
+
+	test("handles whitespace around values", () => {
+		expect(validateNumericIdList("12, 34, 56", "standup ID")).toEqual([12, 34, 56]);
+	});
+
+	test("throws CliError when any value is invalid", () => {
+		expect(() => validateNumericIdList("12,abc,34", "standup ID")).toThrow(CliError);
+	});
+
+	test("throws CliError for zero or negative ids", () => {
+		expect(() => validateNumericIdList("12,0", "standup ID")).toThrow(CliError);
 	});
 });
 


### PR DESCRIPTION
Tracks the v2 API change to `GET /v2/ooo`: the list endpoint now returns periods for every member the caller can view (admins: whole team; members: teammates sharing an active standup) and takes comma-separated `users` / `standups` filters instead of a single `user_id`.

## Changes

- `ooo list`: `--user <id>` replaced by `--users <ids>` and `--standups <ids>` (comma-separated). The two flags are mutually exclusive — the CLI rejects the combination locally with a clear error before any request, mirroring the API's 400.
- Per-element validation up front: `validateSlackIdList` for `--users`, new `validateNumericIdList` (mirroring it) for `--standups`.
- `ooo create --user` is unchanged — the write path still takes `user_id`.
- `geekbot-run` skill updated: team-wide listing documented, `--user` references removed from `ooo list` docs; plugin manifests (Claude + Codex + marketplace) bumped 0.3.0 → 0.4.0.
- Version 2.0.0 — removing the released `ooo list --user` flag is breaking.


## Tests

Handler mapping, mutual-exclusion rejection, command wiring, and validator unit tests updated/added; suite at its pre-existing baseline (all OOO-related tests green), biome + tsc clean.
