### PR TITLE
plugin: declare minCliVersion, gate + surface it in the skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
 	"name": "geekbot",
 	"description": "Manage Geekbot standups, reports, and polls from Claude via the geekbot CLI",
 	"version": "0.4.0",
+	"minCliVersion": "2.0.0",
 	"author": { "name": "Geekbot" },
 	"homepage": "https://github.com/geekbot-com/geekbot-cli"
 }

--- a/plugins/geekbot/.codex-plugin/plugin.json
+++ b/plugins/geekbot/.codex-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
 	"name": "geekbot",
 	"version": "0.4.0",
+	"minCliVersion": "2.0.0",
 	"description": "Manage Geekbot standups, reports, and polls from Codex via the geekbot CLI",
 	"author": { "name": "Geekbot" },
 	"homepage": "https://github.com/geekbot-com/geekbot-cli",

--- a/skills/geekbot-run/SKILL.md
+++ b/skills/geekbot-run/SKILL.md
@@ -31,6 +31,10 @@ Run `check-cli.sh` on first invocation. If it fails:
 - **CLI not found**: Install via `npm install -g geekbot-cli` (requires
   Bun >= 1.3.5 runtime). Note: `npx geekbot-cli` also requires Bun on
   PATH — it is not a Node.js fallback.
+- **CLI outdated** (`cli_outdated`): the installed CLI is older than the
+  `minCliVersion` this plugin declares, so documented flags may not exist
+  yet. Prompt the user to update via `npm install -g geekbot-cli@latest`
+  (offer to run it) and re-run the check before continuing.
 - **Auth not configured**: Guide the user to run `geekbot auth login`,
   which uses the OAuth 2.1 authorization-code + PKCE flow with a
   `http://127.0.0.1:<port>/callback` loopback redirect and writes the

--- a/skills/geekbot-run/check-cli.sh
+++ b/skills/geekbot-run/check-cli.sh
@@ -1,9 +1,40 @@
 #!/usr/bin/env bash
-# Verify geekbot CLI is installed and authenticated.
+# Verify geekbot CLI is installed, new enough for this plugin, and authenticated.
 # Run at the start of any skill invocation.
-# Exit 0 = ready, Exit 1 = not installed, Exit 2 = not authed
+# Exit 0 = ready, 1 = not installed/broken, 2 = not authed,
+# Exit 3 = installed CLI is older than the plugin's minCliVersion
 
 set -euo pipefail
+
+# --- plugin manifest (plugin version + CLI requirement) ---------------------
+# Prefer CLAUDE_PLUGIN_ROOT (set by Claude Code for plugin components, but
+# unreliable in some contexts), then walk up from this script's location:
+# <plugin root>/skills/geekbot-run/check-cli.sh in both the Claude and Codex
+# packagings. Standalone skill installs (npx skills add) ship no manifest —
+# the plugin/requirement checks are skipped there.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PLUGIN_MANIFEST=""
+for candidate in \
+  "${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json" \
+  "$SCRIPT_DIR/../../.claude-plugin/plugin.json" \
+  "$SCRIPT_DIR/../../.codex-plugin/plugin.json"; do
+  if [ -f "$candidate" ]; then
+    PLUGIN_MANIFEST="$candidate"
+    break
+  fi
+done
+
+# First string value for a key in a flat JSON manifest (no jq dependency).
+json_field() {
+  sed -n 's/.*"'"$2"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$1" | head -1
+}
+
+PLUGIN_VERSION=""
+REQUIRED_CLI=""
+if [ -n "$PLUGIN_MANIFEST" ]; then
+  PLUGIN_VERSION=$(json_field "$PLUGIN_MANIFEST" version)
+  REQUIRED_CLI=$(json_field "$PLUGIN_MANIFEST" minCliVersion)
+fi
 
 # Check CLI exists on PATH
 if ! command -v geekbot &>/dev/null; then
@@ -22,15 +53,29 @@ EOF
   exit 1
 fi
 
-# Check auth — use exit code instead of jq to avoid extra dependency
-if ! geekbot auth status &>/dev/null; then
+# Sanitize version to alphanumeric + dots before comparing/embedding in JSON
+SAFE_VERSION=$(echo "$VERSION_OUTPUT" | tr -cd '[:alnum:].')
+
+# Enforce the plugin's CLI requirement before anything else — an outdated
+# CLI may be missing flags the skill documentation relies on.
+if [ -n "$REQUIRED_CLI" ] && [ -n "$SAFE_VERSION" ]; then
+  LOWEST=$(printf '%s\n%s\n' "$REQUIRED_CLI" "$SAFE_VERSION" | sort -V | head -1)
+  if [ "$LOWEST" != "$REQUIRED_CLI" ]; then
+    echo "{\"ok\":false,\"error\":\"cli_outdated\",\"cli_version\":\"${SAFE_VERSION}\",\"plugin_version\":\"${PLUGIN_VERSION}\",\"required_cli\":\"${REQUIRED_CLI}\",\"message\":\"geekbot CLI ${SAFE_VERSION} is older than the ${REQUIRED_CLI} this plugin version (${PLUGIN_VERSION}) requires.\",\"suggestion\":\"Update: npm install -g geekbot-cli@latest\"}"
+    exit 3
+  fi
+fi
+
+# Check auth. `geekbot auth status` exits 0 whenever it can report (even
+# unauthenticated), so read the JSON instead — grep, not jq, to avoid the
+# extra dependency.
+AUTH_OUTPUT=$(geekbot auth status 2>/dev/null || true)
+if ! echo "$AUTH_OUTPUT" | grep -q '"authenticated":[[:space:]]*true'; then
   cat <<'EOF'
 {"ok":false,"error":"auth_not_configured","message":"geekbot CLI is not authenticated.","suggestion":"Run: geekbot auth setup"}
 EOF
   exit 2
 fi
 
-# All good — sanitize version to alphanumeric + dots before embedding in JSON
-SAFE_VERSION=$(echo "$VERSION_OUTPUT" | tr -cd '[:alnum:].')
-echo "{\"ok\":true,\"version\":\"${SAFE_VERSION}\",\"message\":\"geekbot CLI is installed and authenticated\"}"
+echo "{\"ok\":true,\"cli_version\":\"${SAFE_VERSION}\",\"plugin_version\":\"${PLUGIN_VERSION}\",\"required_cli\":\"${REQUIRED_CLI}\",\"message\":\"geekbot CLI is installed and authenticated\"}"
 exit 0

--- a/skills/geekbot-status/SKILL.md
+++ b/skills/geekbot-status/SKILL.md
@@ -16,13 +16,15 @@ Goal: emit a compact health check for the CLI. Useful both as a user-triggered `
    command -v geekbot
    ```
 
-2. If found, capture its version:
+2. Run the shared health check (emits JSON with `cli_version`, `plugin_version`, `required_cli`, and on failure an `error` + `suggestion`):
 
    ```bash
-   geekbot --version
+   bash "$(dirname of this skill)/../geekbot-run/check-cli.sh"
    ```
 
-3. Check auth state (JSON):
+   (Resolve the path relative to this skill's directory — `geekbot-run` is a sibling skill.)
+
+3. If auth needs detail beyond the check's yes/no, capture it:
 
    ```bash
    geekbot auth status
@@ -35,13 +37,17 @@ A single compact markdown table. Report only what was checked — no "next step"
 | Check | Value |
 |---|---|
 | Binary | `/home/user/.nvm/versions/node/vX/bin/geekbot` |
-| Version | `0.2.4` |
+| Version | `2.0.0` |
+| Plugin | `0.4.0` (requires CLI >= `2.0.0`) |
 | Authenticated | yes (sabpap@geekbot.com) |
 
-If the binary is missing, show `Binary: not installed` and leave Version/Authenticated blank.
-If the binary exists but auth is missing, show `Authenticated: no`.
+- `Version` is `cli_version`; `Plugin` combines `plugin_version` and `required_cli`.
+- If `plugin_version` is empty (skills installed standalone, no plugin manifest), omit the Plugin row.
+- If the binary is missing, show `Binary: not installed` and leave the other rows blank.
+- If the binary exists but auth is missing, show `Authenticated: no`.
+- If the check reports `cli_outdated`, show the installed version in `Version` and mark it, e.g. `1.2.0` (outdated — plugin requires >= `2.0.0`).
 
-Keep it to the table — no prose about remediation.
+Keep it to the table — no prose about remediation, except the outdated case below.
 
 ## Failure recovery (only when status or an action skill fails)
 
@@ -49,5 +55,6 @@ This guidance applies when `/geekbot:geekbot-status`, the main action skill, or 
 
 - Binary missing → recommend running `/geekbot:geekbot-setup`.
 - Auth missing or invalid → recommend running `/geekbot:geekbot-setup`.
+- `cli_outdated` → prompt the user to update, e.g. *"The installed geekbot CLI (1.2.0) is older than this plugin requires (2.0.0). Run `npm install -g geekbot-cli@latest` to update."* Offer to run the update for them.
 
 Surface the recommendation as a short follow-up line after the failure, e.g. *"Run `/geekbot:geekbot-setup` to install and authenticate the CLI."*


### PR DESCRIPTION
Introduces a version dependency between the plugin and the geekbot-cli npm package, so an outdated CLI is detected and the agent prompts an update instead of hitting missing flags.

## Changes

- **Manifests** (Claude + Codex): new `"minCliVersion": "2.0.0"` custom key next to the plugin version. Verified safe on both sides: Claude Code ignores unknown manifest fields at load time (`claude plugin validate` passes, one advisory warning), and Codex installs/enables the plugin cleanly with the field present.
- **`check-cli.sh`**: locates the plugin manifest via `$CLAUDE_PLUGIN_ROOT` with a fallback to its own script path (covers both packagings and the documented CLAUDE_PLUGIN_ROOT reliability bugs), reads `version`/`minCliVersion` with sed (no jq), compares with `sort -V`, and fails with a new `cli_outdated` error (exit 3) suggesting `npm install -g geekbot-cli@latest`. Standalone skill installs without a manifest skip the gate.
- **`geekbot-status`**: runs the shared check and gains a `Plugin` row — e.g. `0.4.0 (requires CLI >= 2.0.0)` — with the Version cell marked `(outdated — …)` and an update prompt when the gate trips. **`geekbot-run`** preflight documents the new failure mode.
- **Bug fix**: the auth gate never worked — `geekbot auth status` exits 0 even when unauthenticated, so the script now reads the `"authenticated"` flag from its JSON instead of relying on the exit code.
